### PR TITLE
🔧 Chore[BE](build): yml 파일 수정 (Mysql 사용 항목 추가)

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/db_dev?useSSL=false&serverTimezone=UTC
+    username: root
+    password: root123414
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:h2:./dv_test;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Matching-Platform

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  profiles:
+    active: dev
+  output:
+    ansi:
+      enabled: always
+  datasource:
+    hikari:
+      auto-commit: false
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.orm.jdbc.extract: TRACE
+    org.springframework.transaction.interceptor: TRACE


### PR DESCRIPTION
### 🚀 작업 내용
- 기존의 application.properties를 yml 파일로 변경
- 기본 파일과 함께 dev, test 파일 분리

### ✅ 체크리스트
- [ ] 코드 빌드 성공
- [ ] 테스트 통과
- [ ] 문서 업데이트
- [x] 형식/스타일 가이드 준수
- [ ] 필요 시 마이그레이션/DB 변경 적용
- [ ] 제출 전 코드 포맷팅(ctrl + alt + L) 사용

### 🔗 관련 이슈

### 💡 추가 설명 / 주의 사항
- dev 환경에서는 mysql을, 테스트 환경에서는 h2를 사용하도록 구성했습니다.
- mysql의 경우 application-dev.yml 파일에서 계정명 및 비밀번호를 확인할 수 있습니다.