### PR TITLE
✨ Feat[BE](project): project  다건/단건 조회

### DIFF
--- a/backend/src/main/java/com/back/domain/project/project/controller/ApiV1ProjectController.java
+++ b/backend/src/main/java/com/back/domain/project/project/controller/ApiV1ProjectController.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/projects")
@@ -113,5 +114,17 @@ public class ApiV1ProjectController {
         List<SkillDto> skillDtoList = skillService.findByProjectId(id);
         List<InterestDto> interestDtoList = interestService.findByProjectId(id);
         return new ProjectDto(project, skillDtoList, interestDtoList);
+    }
+
+    @GetMapping
+    @Transactional(readOnly = true)
+    public List<ProjectDto> getItems() {
+        return projectService.getList().stream()
+                .map(project -> {
+                    List<SkillDto> skillDtoList = skillService.findByProjectId(project.getId());
+                    List<InterestDto> interestDtoList = interestService.findByProjectId(project.getId());
+                    return new ProjectDto(project, skillDtoList, interestDtoList);
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/back/domain/project/project/service/ProjectService.java
+++ b/backend/src/main/java/com/back/domain/project/project/service/ProjectService.java
@@ -150,4 +150,8 @@ public class ProjectService {
             projectInterestRepository.save(new ProjectInterest(project, interest));
         }
     }
+
+    public List<Project> getList() {
+        return projectRepository.findAll();
+    }
 }

--- a/backend/src/test/java/com/back/domain/project/project/controller/ApiV1ProjectControllerTest.java
+++ b/backend/src/test/java/com/back/domain/project/project/controller/ApiV1ProjectControllerTest.java
@@ -288,6 +288,63 @@ class ApiV1ProjectControllerTest {
     @Test
     @DisplayName("프로젝트 다건조회")
     void t5() throws Exception {
+        // API 호출
+        ResultActions resultActions = mvc
+                .perform(get("/api/v1/projects"))
+                .andDo(print());
 
+        // DB에서 실제 프로젝트 리스트 조회
+        List<Project> projectList = projectService.getList();
+
+        // 기본 상태 코드 및 핸들러 검증
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1ProjectController.class))
+                .andExpect(handler().methodName("getItems"))
+                .andExpect(jsonPath("$", Matchers.hasSize(projectList.size()))); // 최상위 배열 길이 검증
+
+        // 각 프로젝트별 상세 검증
+        for (int i = 0; i < projectList.size(); i++) {
+            Project project = projectList.get(i);
+
+            resultActions
+                    .andExpect(jsonPath(String.format("$[%d].id", i)).value(project.getId()))
+                    .andExpect(jsonPath(String.format("$[%d].title", i)).value(project.getTitle()))
+                    .andExpect(jsonPath(String.format("$[%d].summary", i)).value(project.getSummary()))
+                    .andExpect(jsonPath(String.format("$[%d].duration", i)).value(project.getDuration()))
+                    .andExpect(jsonPath(String.format("$[%d].price", i)).value(project.getPrice().doubleValue()))
+                    .andExpect(jsonPath(String.format("$[%d].preferredCondition", i)).value(project.getPreferredCondition()))
+                    .andExpect(jsonPath(String.format("$[%d].payCondition", i)).value(project.getPayCondition()))
+                    .andExpect(jsonPath(String.format("$[%d].workingCondition", i)).value(project.getWorkingCondition()))
+                    .andExpect(jsonPath(String.format("$[%d].description", i)).value(project.getDescription()))
+                    .andExpect(jsonPath(String.format("$[%d].deadline", i), Matchers.startsWith(project.getDeadline().toString().substring(0, 20))))
+                    .andExpect(jsonPath(String.format("$[%d].ownerName", i)).value(project.getOwner().getName()))
+                    .andExpect(jsonPath(String.format("$[%d].status", i)).value(project.getStatus().toString()))
+                    .andExpect(jsonPath(String.format("$[%d].createDate", i), Matchers.startsWith(project.getCreateDate().toString().substring(0, 20))))
+                    .andExpect(jsonPath(String.format("$[%d].modifyDate", i), Matchers.startsWith(project.getModifyDate().toString().substring(0, 20))));
+
+            // 각 프로젝트의 스킬, 관심사 리스트 검증
+            List<ProjectSkill> dbSkills = projectService.findProjectSkillAllByProject(project);
+            List<ProjectInterest> dbInterests = projectService.findProjectInterestAllByProject(project);
+
+            resultActions
+                    .andExpect(jsonPath(String.format("$[%d].skills", i), Matchers.hasSize(dbSkills.size())))
+                    .andExpect(jsonPath(String.format("$[%d].interests", i), Matchers.hasSize(dbInterests.size())));
+
+            for (int j = 0; j < dbSkills.size(); j++) {
+                ProjectSkill ps = dbSkills.get(j);
+                resultActions
+                        .andExpect(jsonPath(String.format("$[%d].skills[%d].id", i, j)).value(ps.getSkill().getId()))
+                        .andExpect(jsonPath(String.format("$[%d].skills[%d].name", i, j)).value(ps.getSkill().getName()));
+            }
+
+            for (int j = 0; j < dbInterests.size(); j++) {
+                ProjectInterest pi = dbInterests.get(j);
+                resultActions
+                        .andExpect(jsonPath(String.format("$[%d].interests[%d].id", i, j)).value(pi.getInterest().getId()))
+                        .andExpect(jsonPath(String.format("$[%d].interests[%d].name", i, j)).value(pi.getInterest().getName()));
+            }
+        }
     }
+
 }


### PR DESCRIPTION
### 🚀 작업 내용
- 프로젝트 단건 조회 (`/api/v1/projects/{projectId}`) 다건 조회 (`/api/v1/projects/`) API 구현 

### ✅ 체크리스트
- [x] 코드 빌드 성공
- [x] 테스트 통과
- [ ] 문서 업데이트
- [ ] 형식/스타일 가이드 준수
- [ ] 필요 시 마이그레이션/DB 변경 적용
- [ ] 제출 전 코드 포맷팅(ctrl + alt + L) 사용

### 🔗 관련 이슈
- 이슈 번호: #16 #18 
- 참고 링크: 설계 문서, API 명세서

### 💡 추가 설명 / 주의 사항
- 프로젝트의 단건/다건 조회시 ProjectDto에 담아 오도록 만들었습니다.
- 이에 따라 등록한 client의 닉네임(ownerName)과 기술 스택(skill), 관심 분야(interest) 리스트를 받아오게 만들었습니다.