### PR TITLE
✨ Feat[BE](freelnacer-entity) Member에 Freelancer 필드 추가 및 어노테이션 설정

### DIFF
--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/controller/FreelancerController.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/controller/FreelancerController.java
@@ -2,14 +2,18 @@ package com.back.domain.freelancer.freelancer.controller;
 
 import com.back.domain.freelancer.freelancer.dto.FreelancerFilterDto;
 import com.back.domain.freelancer.freelancer.dto.FreelancerSummaryDto;
+import com.back.domain.freelancer.freelancer.dto.FreelancerUpdateFormDto;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.freelancer.freelancer.service.FreelancerService;
 import com.back.global.response.ApiResponse;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +23,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class FreelancerController {
 
     private final FreelancerService freelancerService;
+
+    @PutMapping
+    public ApiResponse<FreelancerUpdateFormDto> updateFreelancer(FreelancerUpdateFormDto info) {
+        freelancerService.updateFreelancer(
+                info.id(),
+                info.job(),
+                info.freelancerEmail(),
+                info.comment(),
+                info.career()
+        );
+
+        return new ApiResponse<>(
+                "201",
+                "프리랜서 정보 변경",
+                // TODO : 변경된 정보 응답
+                null
+        );
+    }
 
     @GetMapping
     public ApiResponse<Page<FreelancerSummaryDto>> getFreelancers(

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/dto/FreelancerSummaryDto.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/dto/FreelancerSummaryDto.java
@@ -6,6 +6,7 @@ import com.back.domain.freelancer.join.entity.FreelancerSkill;
 import java.util.List;
 
 public record FreelancerSummaryDto(
+        String name,
         Long id,
         String job,
         float ratingAvg,
@@ -13,6 +14,7 @@ public record FreelancerSummaryDto(
 ) {
     public FreelancerSummaryDto(Freelancer freelancer) {
         this(
+                freelancer.getMember().getName(),
                 freelancer.getId(),
                 freelancer.getJob(),
                 freelancer.getRatingAvg(),

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/dto/FreelancerUpdateFormDto.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/dto/FreelancerUpdateFormDto.java
@@ -1,0 +1,12 @@
+package com.back.domain.freelancer.freelancer.dto;
+
+import java.util.Map;
+
+public record FreelancerUpdateFormDto(
+        Long id,
+        String job,
+        String freelancerEmail,
+        String comment,
+        Map<String, Integer> career
+) {
+}

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/entity/Freelancer.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/entity/Freelancer.java
@@ -50,4 +50,21 @@ public class Freelancer {
 
     @OneToMany(mappedBy = "freelancer")
     private List<FreelancerInterest> interests = new ArrayList<>();
+
+    public Freelancer(Member member) {
+        this.member = member;
+    }
+
+    public Freelancer(Member member, String job, String freelancerEmail, String comment, Map<String, Integer> career) {
+        this.member = member;
+        this.job = job;
+        this.freelancerEmail = freelancerEmail;
+        this.comment = comment;
+        this.career = career;
+        this.ratingAvg = 0.0f;
+    }
+
+    public void join(Member member) {
+        this.member = member;
+    }
 }

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/service/FreelancerService.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/service/FreelancerService.java
@@ -2,9 +2,12 @@ package com.back.domain.freelancer.freelancer.service;
 
 import com.back.domain.freelancer.freelancer.dto.FreelancerFilterDto;
 import com.back.domain.freelancer.freelancer.dto.FreelancerSummaryDto;
+import com.back.domain.freelancer.freelancer.dto.FreelancerUpdateFormDto;
 import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.freelancer.freelancer.repository.FreelancerRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -29,5 +32,13 @@ public class FreelancerService {
 
     private Page<FreelancerSummaryDto> convertToSummary(Page<Freelancer> freelancers) {
         return freelancers.map(FreelancerSummaryDto::new);
+    }
+
+    public void updateFreelancer(Long id,
+                                 String job,
+                                 String freelancerEmail,
+                                 String comment,
+                                 Map<String, Integer> career
+    ) {
     }
 }

--- a/backend/src/main/java/com/back/domain/member/member/constant/Role.java
+++ b/backend/src/main/java/com/back/domain/member/member/constant/Role.java
@@ -1,7 +1,19 @@
 package com.back.domain.member.member.constant;
 
+import org.springframework.util.StringUtils;
+
 public enum Role {
-    CLIENT,
-    FREELANCER,
-    ADMIN
+    CLIENT("Client"),
+    FREELANCER("Freelancer"),
+    ADMIN("Admin");
+
+    private final String description;
+
+    Role(String description) {
+        this.description = description;
+    }
+
+    public static boolean isFreelancer(String description) {
+        return Role.FREELANCER.description.equalsIgnoreCase(description);
+    }
 }

--- a/backend/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,17 +1,19 @@
 package com.back.domain.member.member.entity;
 
-import com.back.domain.member.member.constant.Role;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.member.member.constant.MemberStatus;
+import com.back.domain.member.member.constant.Role;
 import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -40,6 +42,9 @@ public class Member extends BaseEntity {
 
     private LocalDateTime deleteDate;
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Freelancer freelancer;
+
     public Member(String role, String name, String username, String password, String email) {
         this.role = Role.valueOf(role);
         this.name = name;
@@ -47,6 +52,13 @@ public class Member extends BaseEntity {
         this.password = password;
         this.email = email;
         this.status = MemberStatus.valueOf("ACTIVE");
+    }
+
+    // Freelancer 등록 메서드 추가
+    public void registerFreelancer(Freelancer freelancer) {
+        this.freelancer = freelancer;
+        this.role = Role.FREELANCER;
+        freelancer.join(this);
     }
 
     public void changeStatus(String status) {

--- a/backend/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -1,13 +1,16 @@
 package com.back.domain.member.member.service;
 
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.freelancer.freelancer.repository.FreelancerRepository;
+import com.back.domain.member.member.constant.Role;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +18,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Member join(String role, String name, String username, String password, String passwordConfirm, String email) {
+    @Transactional
+    public Member join(String role, String name, String username, String password, String passwordConfirm,
+                       String email) {
         //이미 사용중인 아이디인지 확인
         memberRepository.findByUsername(username)
                 .ifPresent(_member -> {
@@ -32,6 +37,11 @@ public class MemberService {
 
         //DTO -> ENTITY 변환
         Member member = new Member(role, name, username, encodedPassword, email);
+
+        if (Role.isFreelancer(role)) {
+            Freelancer freelancer = new Freelancer(member);
+            member.registerFreelancer(freelancer);
+        }
 
         //DB 반영 후 반환
         return memberRepository.save(member);

--- a/backend/src/test/java/com/back/domain/freelancer/freelancer/controller/FreelancerControllerTest.java
+++ b/backend/src/test/java/com/back/domain/freelancer/freelancer/controller/FreelancerControllerTest.java
@@ -3,14 +3,21 @@ package com.back.domain.freelancer.freelancer.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.back.domain.freelancer.freelancer.dto.FreelancerSummaryDto;
 import com.back.domain.freelancer.freelancer.service.FreelancerService;
+import com.back.domain.member.member.service.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -27,13 +34,15 @@ class FreelancerControllerTest {
     private MockMvc mvc;
     @Autowired
     private FreelancerService freelancerService;
+    @Autowired
+    private MemberService memberService;
 
     @Test
     @DisplayName("목록보기 응답 - 200")
     void t1() throws Exception {
         ResultActions resultActions = mvc
                 .perform(
-                        get("/freelancers")
+                        get("/api/v1/freelancers")
                 )
                 .andDo(print());
 
@@ -51,10 +60,19 @@ class FreelancerControllerTest {
     void t1_data() throws Exception {
         ResultActions resultActions = mvc
                 .perform(
-                        get("/freelancers")
+                        get("/api/v1/freelancers")
                 )
                 .andDo(print());
 
         // TODO: 데이터 확인
+        Page<FreelancerSummaryDto> freelancers = freelancerService.findAll(null, PageRequest.of(0, 20));
+
+        resultActions
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("프리랜서 목록"))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].name").value("프리랜서1"))
+                .andExpect(jsonPath("$.data.content[1].name").value("프리랜서2"));
     }
 }


### PR DESCRIPTION
🚀 작업 내용
- Member에 Freelancer 필드 및 관련 편의 메소드 추가
- Role의 isFreelancer로 freelancer 검사 로직 추가
- MemberService join시 Freelancer임을 간단히 확인하고 Freelancer 같이 등록
- Member join시 Freelancer(FK,PK)가 같이 등록됨을 확인하는 테스트 추가

📑  해당 이슈 남은 내용
- 없음

🛠 변경 파일 종류:
코드: .java (Freelancer관련, standard Converter)

✅ 체크리스트
- ✔️ 코드 빌드 성공
- ✔️ 테스트 통과
- ❌ 문서 업데이트
- ✔️ 형식/스타일 가이드 준수
- ❌필요 시 마이그레이션/DB 변경 적용
- ✔️  제출 전 코드 포맷팅(ctrl + alt + L) 사용

🔗 관련 이슈
이슈 번호: #28  

💡 추가 설명 / 주의 사항
바로 PR올렸어야 되는데 다른작업 추가로 진행하여 updateForm등의 다른 파일 변경도 같이 PR에 포함되어 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added API to update freelancer profiles (job, email, comment, career).
  - Freelancer listings now include freelancer names.
  - Signing up as a freelancer now auto-creates a freelancer profile.

- Refactor
  - Standardized freelancer API routes under /api/v1.

- Tests
  - Updated tests to cover new response fields and the /api/v1/freelancers endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->