### PR TITLE
✨ Feat[BE](auth): JWT 기반 인증/인가 구현

### DIFF
--- a/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
@@ -1,0 +1,89 @@
+package com.back.domain.member.member.controller;
+
+import com.back.domain.member.member.dto.MemberDto;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.response.ApiResponse;
+import com.back.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 인증/인가 기능 테스트용 Controller입니다.
+ *
+ * - Postman 및 테스트 케이스에서 정상 동작 확인용
+ * - 개발 중 예시로 활용 가능
+ *
+ * 개발 완료 후에는 반드시 제거해야 합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/test")
+@RequiredArgsConstructor
+public class AuthTestController {
+
+    private final MemberService memberService;
+
+    // 인증 필요 없음
+    @GetMapping("/public")
+    public ApiResponse<Void> publicEndpoint() {
+        return new ApiResponse<>("200", "누구나 접근 가능");
+    }
+
+    // 인증된 사용자만 접근 가능 + ACTIVE 상태 체크
+    @GetMapping("/auth")
+    public ApiResponse<MemberDto> authenticatedUserEndpoint() {
+        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (!user.isActive()) {
+            return new ApiResponse<>("403-2", "비활성 계정입니다.");
+        }
+
+        return new ApiResponse<>("200", "인증된 사용자 접근 성공", new MemberDto(user));
+    }
+
+    // 클라이언트만 접근 가능 + ACTIVE 상태 체크
+    @GetMapping("/auth/client")
+    public ApiResponse<MemberDto> clientEndpoint() {
+        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (!user.isActive()) {
+            return new ApiResponse<>("403-2", "비활성 계정입니다.");
+        }
+
+        return new ApiResponse<>("200", "클라이언트 접근 성공", new MemberDto(user));
+    }
+
+    // 프리랜서만 접근 가능 + ACTIVE 상태 체크
+    @GetMapping("/auth/freelance")
+    public ApiResponse<MemberDto> freelanceEndpoint() {
+        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (!user.isActive()) {
+            return new ApiResponse<>("403-2", "비활성 계정입니다.");
+        }
+
+        return new ApiResponse<>("200", "프리랜서 접근 성공", new MemberDto(user));
+    }
+
+    // 관리자만 접근 가능
+    @GetMapping("/auth/admin")
+    public ApiResponse<MemberDto> adminEndpoint() {
+        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        return new ApiResponse<>("200", "관리자 접근 성공", new MemberDto(user));
+    }
+
+    // 인증 정보를 통해 member 객체 조회
+    @GetMapping("/auth/me")
+    public ApiResponse<MemberDto> myInfo(@AuthenticationPrincipal CustomUserDetails user) {
+
+        // DB에서 실제 Member 객체 조회
+        Member member = memberService.findById(user.getId());
+
+        return new ApiResponse<>("200", "내 정보 조회 성공", new MemberDto(member));
+    }
+}

--- a/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
@@ -8,7 +8,6 @@ import com.back.global.security.CustomUserDetails;
 import com.back.global.security.annotation.CheckActive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,8 +36,7 @@ public class AuthTestController {
     // 인증된 사용자만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth")
     @CheckActive
-    public ApiResponse<MemberDto> authenticatedUserEndpoint() {
-        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ApiResponse<MemberDto> authenticatedUserEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
 
         if (!user.isActive()) {
             return new ApiResponse<>("403-2", "비활성 계정입니다.");
@@ -50,12 +48,7 @@ public class AuthTestController {
     // 클라이언트만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth/client")
     @CheckActive
-    public ApiResponse<MemberDto> clientEndpoint() {
-        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        if (!user.isActive()) {
-            return new ApiResponse<>("403-2", "비활성 계정입니다.");
-        }
+    public ApiResponse<MemberDto> clientEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
 
         return new ApiResponse<>("200", "클라이언트 접근 성공", new MemberDto(user));
     }
@@ -63,20 +56,14 @@ public class AuthTestController {
     // 프리랜서만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth/freelancer")
     @CheckActive
-    public ApiResponse<MemberDto> freelanceEndpoint() {
-        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        if (!user.isActive()) {
-            return new ApiResponse<>("403-2", "비활성 계정입니다.");
-        }
+    public ApiResponse<MemberDto> freelanceEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
 
         return new ApiResponse<>("200", "프리랜서 접근 성공", new MemberDto(user));
     }
 
     // 관리자만 접근 가능
     @GetMapping("/auth/admin")
-    public ApiResponse<MemberDto> adminEndpoint() {
-        CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ApiResponse<MemberDto> adminEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
 
         return new ApiResponse<>("200", "관리자 접근 성공", new MemberDto(user));
     }

--- a/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
@@ -5,7 +5,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.response.ApiResponse;
 import com.back.global.security.CustomUserDetails;
-import com.back.global.security.annotation.CheckActive;
+import com.back.global.security.annotation.OnlyActiveMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,24 +30,21 @@ public class AuthTestController {
     // 인증 필요 없음
     @GetMapping("/public")
     public ApiResponse<Void> publicEndpoint() {
+
         return new ApiResponse<>("200", "누구나 접근 가능");
     }
 
     // 인증된 사용자만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth")
-    @CheckActive
+    @OnlyActiveMember
     public ApiResponse<MemberDto> authenticatedUserEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
-
-        if (!user.isActive()) {
-            return new ApiResponse<>("403-2", "비활성 계정입니다.");
-        }
 
         return new ApiResponse<>("200", "인증된 사용자 접근 성공", new MemberDto(user));
     }
 
     // 클라이언트만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth/client")
-    @CheckActive
+    @OnlyActiveMember
     public ApiResponse<MemberDto> clientEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
 
         return new ApiResponse<>("200", "클라이언트 접근 성공", new MemberDto(user));
@@ -55,7 +52,7 @@ public class AuthTestController {
 
     // 프리랜서만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth/freelancer")
-    @CheckActive
+    @OnlyActiveMember
     public ApiResponse<MemberDto> freelanceEndpoint(@AuthenticationPrincipal CustomUserDetails user) {
 
         return new ApiResponse<>("200", "프리랜서 접근 성공", new MemberDto(user));

--- a/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
@@ -61,7 +61,7 @@ public class AuthTestController {
     }
 
     // 프리랜서만 접근 가능 + ACTIVE 상태 체크
-    @GetMapping("/auth/freelance")
+    @GetMapping("/auth/freelancer")
     @CheckActive
     public ApiResponse<MemberDto> freelanceEndpoint() {
         CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/AuthTestController.java
@@ -5,6 +5,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.response.ApiResponse;
 import com.back.global.security.CustomUserDetails;
+import com.back.global.security.annotation.CheckActive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -35,6 +36,7 @@ public class AuthTestController {
 
     // 인증된 사용자만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth")
+    @CheckActive
     public ApiResponse<MemberDto> authenticatedUserEndpoint() {
         CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
@@ -47,6 +49,7 @@ public class AuthTestController {
 
     // 클라이언트만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth/client")
+    @CheckActive
     public ApiResponse<MemberDto> clientEndpoint() {
         CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
@@ -59,6 +62,7 @@ public class AuthTestController {
 
     // 프리랜서만 접근 가능 + ACTIVE 상태 체크
     @GetMapping("/auth/freelance")
+    @CheckActive
     public ApiResponse<MemberDto> freelanceEndpoint() {
         CustomUserDetails user = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 

--- a/backend/src/main/java/com/back/domain/member/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/back/domain/member/member/dto/MemberDto.java
@@ -1,25 +1,29 @@
 package com.back.domain.member.member.dto;
 
-import com.back.domain.member.member.constant.Role;
-import com.back.domain.member.member.constant.MemberStatus;
 import com.back.domain.member.member.entity.Member;
-
-import java.time.LocalDateTime;
+import com.back.global.security.CustomUserDetails;
 
 public record MemberDto(
-        long id,
+        Long id,
         String name,
-        Role role,
-        MemberStatus status,
-        LocalDateTime createDate
+        String role,
+        String status
 ) {
     public MemberDto(Member member) {
         this(
                 member.getId(),
                 member.getName(),
-                member.getRole(),
-                member.getStatus(),
-                member.getCreateDate()
+                member.getRole().name(),
+                member.getStatus().name()
+        );
+    }
+
+    public MemberDto(CustomUserDetails user) {
+        this(
+                user.getId(),
+                user.getName(),
+                user.getRole(),
+                user.getStatus()
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/member/member/dto/MemberJoinReq.java
+++ b/backend/src/main/java/com/back/domain/member/member/dto/MemberJoinReq.java
@@ -7,13 +7,13 @@ import jakarta.validation.constraints.Size;
 public record MemberJoinReq(
         @NotBlank
         String role,
-        @NotBlank @Size(min = 2, max = 10)
+        @NotBlank @Size(min = 2, max = 20)
         String name,
-        @NotBlank @Size(min = 2, max = 10)
+        @NotBlank @Size(min = 2, max = 20)
         String username,
-        @NotBlank @Size(min = 4, max = 12)
+        @NotBlank @Size(min = 4, max = 20)
         String password,
-        @NotBlank @Size(min = 4, max = 12)
+        @NotBlank @Size(min = 4, max = 20)
         String passwordConfirm,
         @NotBlank @Email
         String email

--- a/backend/src/main/java/com/back/domain/member/member/dto/MemberLoginReq.java
+++ b/backend/src/main/java/com/back/domain/member/member/dto/MemberLoginReq.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record MemberLoginReq(
-        @NotBlank @Size(min = 2, max = 10)
+        @NotBlank @Size(min = 2, max = 20)
         String username,
-        @NotBlank @Size(min = 4, max = 12)
+        @NotBlank @Size(min = 4, max = 20)
         String password
 ) { }

--- a/backend/src/main/java/com/back/domain/member/member/service/AuthService.java
+++ b/backend/src/main/java/com/back/domain/member/member/service/AuthService.java
@@ -61,4 +61,8 @@ public class AuthService {
         return jwtProvider.genRefreshToken(claims);
     }
 
+    public String reissueAccessToken(Member member) {
+        return genAccessToken(member);
+    }
+
 }

--- a/backend/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/backend/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -6,11 +6,12 @@ import com.back.domain.member.member.constant.Role;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +70,9 @@ public class MemberService {
         if(!passwordEncoder.matches(password, member.getPassword())) {
             throw new ServiceException("401-2", "비밀번호가 일치하지 않습니다.");
         }
+    }
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id).orElseThrow(() -> new ServiceException("404-1", "해당 ID를 가진 회원을 찾을 수 없습니다."));
     }
 }

--- a/backend/src/main/java/com/back/global/app/AppConfig.java
+++ b/backend/src/main/java/com/back/global/app/AppConfig.java
@@ -1,0 +1,31 @@
+package com.back.global.app;
+
+import com.back.standard.json.JsonUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    private static ObjectMapper objectMapper;
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        AppConfig.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        JsonUtil.objectMapper = objectMapper;
+    }
+}

--- a/backend/src/main/java/com/back/global/aspect/CheckActiveAspect.java
+++ b/backend/src/main/java/com/back/global/aspect/CheckActiveAspect.java
@@ -1,0 +1,34 @@
+package com.back.global.aspect;
+
+import com.back.global.response.ApiResponse;
+import com.back.global.security.CustomUserDetails;
+import jakarta.servlet.http.HttpServletResponse;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+@Aspect
+@Component
+public class CheckActiveAspect {
+
+    private final HttpServletResponse response;
+
+    public CheckActiveAspect(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    @Around("@annotation(com.back.global.security.annotation.CheckActive) || @within(com.back.global.security.annotation.CheckActive)")
+    public Object checkActive(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof CustomUserDetails user) {
+            if (!user.isActive()) {
+                response.setStatus(403);
+                return new ApiResponse<>("403-2", "비활성 계정입니다.");
+            }
+        }
+
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/main/java/com/back/global/aspect/CheckActiveAspect.java
+++ b/backend/src/main/java/com/back/global/aspect/CheckActiveAspect.java
@@ -18,7 +18,7 @@ public class CheckActiveAspect {
         this.response = response;
     }
 
-    @Around("@annotation(com.back.global.security.annotation.CheckActive) || @within(com.back.global.security.annotation.CheckActive)")
+    @Around("@annotation(com.back.global.security.annotation.OnlyActiveMember) || @within(com.back.global.security.annotation.OnlyActiveMember)")
     public Object checkActive(ProceedingJoinPoint joinPoint) throws Throwable {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 

--- a/backend/src/main/java/com/back/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/back/global/jwt/JwtProvider.java
@@ -1,10 +1,12 @@
 package com.back.global.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.Map;
@@ -30,18 +32,22 @@ public class JwtProvider {
         this.refreshExpireMillis = refreshExpireSeconds * 1000L;
     }
 
+    // Key 가져오는 helper
+    private Key getKey(boolean isAccessToken) {
+        String secret = isAccessToken ? accessSecret : refreshSecret;
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
     // AccessToken 생성
     public String genAccessToken(Map<String, Object> claims) {
         Date issuedAt = new Date();
         Date expiration = new Date(issuedAt.getTime() + accessExpireMillis);
 
-        Key key = Keys.hmacShaKeyFor(accessSecret.getBytes());
-
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(issuedAt)
                 .setExpiration(expiration)
-                .signWith(key)
+                .signWith(getKey(true))
                 .compact();
     }
 
@@ -50,40 +56,37 @@ public class JwtProvider {
         Date issuedAt = new Date();
         Date expiration = new Date(issuedAt.getTime() + refreshExpireMillis);
 
-        Key key = Keys.hmacShaKeyFor(refreshSecret.getBytes());
-
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(issuedAt)
                 .setExpiration(expiration)
-                .signWith(key)
+                .signWith(getKey(false))
                 .compact();
     }
 
+    // Claims 추출
+    public Claims getClaims(String token, boolean isAccessToken) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(getKey(isAccessToken))  // Key 타입 필요
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (Exception e) {
+            return null; // 만료, 변조 등 실패 시 null
+        }
+    }
 
-    // 토큰 검증
-//    public boolean validateToken(String token) {
-//        try {
-//            Jwts.parserBuilder()
-//                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-//                    .build()
-//                    .parseClaimsJws(token);
-//            return true;
-//        } catch (Exception e) {
-//            return false;
-//        }
-//    }
-
-    // claim 추출
-//    public Claims getClaims(String token) {
-//        try {
-//            return Jwts.parserBuilder()
-//                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-//                    .build()
-//                    .parseClaimsJws(token)
-//                    .getBody();
-//        } catch (Exception e) {
-//            return null;
-//        }
-//    }
+    // 토큰 유효성 검증
+    public boolean validateToken(String token, boolean isAccessToken) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(getKey(isAccessToken))
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/backend/src/main/java/com/back/global/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/back/global/security/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.back.global.security;
 
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -7,6 +8,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
+@Getter
 public class CustomUserDetails implements UserDetails {
 
     private final Long id;
@@ -38,23 +40,6 @@ public class CustomUserDetails implements UserDetails {
 
     public boolean isWithDrawn() {
         return status.equals("WITHDRAWN");
-    }
-
-    //getter
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getRole() {
-        return role;
-    }
-
-    public String getStatus() {
-        return status;
     }
 
     //사용하지 않는 getter

--- a/backend/src/main/java/com/back/global/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/back/global/security/CustomUserDetails.java
@@ -1,0 +1,70 @@
+package com.back.global.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String name;
+    private final String role;
+    private final String status;
+
+    public CustomUserDetails(Long id, String name, String role, String status) {
+        this.id = id;
+        this.name = name;
+        this.role = role;
+        this.status = status;
+    }
+
+    //Role 설정
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    //상태 확인
+    public boolean isActive() {
+        return status.equals("ACTIVE");
+    }
+
+    public boolean isInactive() {
+        return status.equals("INACTIVE");
+    }
+
+    public boolean isWithDrawn() {
+        return status.equals("WITHDRAWN");
+    }
+
+    //getter
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    //사용하지 않는 getter
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return "";
+    }
+}

--- a/backend/src/main/java/com/back/global/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/back/global/security/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.back.global.security;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,6 +9,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
+@Slf4j
 @Getter
 public class CustomUserDetails implements UserDetails {
 
@@ -44,12 +46,16 @@ public class CustomUserDetails implements UserDetails {
 
     //사용하지 않는 getter
     @Override
+    @Deprecated
     public String getPassword() {
+        log.warn("getPassword() 호출됨 : JWT 기반 인증에서 호출되어서는 안 됩니다.");
         return "";
     }
 
     @Override
+    @Deprecated
     public String getUsername() {
+        log.warn("getUsername() 호출됨 : JWT 기반 인증에서 호출되어서는 안 됩니다.");
         return "";
     }
 }

--- a/backend/src/main/java/com/back/global/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/back/global/security/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.back.global.security;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * 테스트를 위한 클래스입니다.
+ *
+ * - 실제 개발/운영 환경에서는 사용되지 않음
+ * - 테스트에서 @WithUserDetails 사용을 위해 구현됨
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberService memberService;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberService.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException(username + " 회원을 찾을 수 없습니다."));
+        return new CustomUserDetails(
+                member.getId(),
+                member.getName(),
+                member.getRole().name(),
+                member.getStatus().name()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,112 @@
+package com.back.global.security;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.AuthService;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.jwt.JwtProvider;
+import com.back.global.web.CookieHelper;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final CookieHelper cookieHelper;
+    private final MemberService memberService;
+    private final AuthService authService;
+
+    private final List<String> skipUrls = List.of(
+            "/api/v1/members/login",
+            "/api/v1/members/join"
+    );
+
+    //요청당 한 번만 호출되는 로직, doFilter는 같은 요청에 대해 여러번 호출될 수 있음
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //api 요청이 아니면 패스
+        if(!request.getRequestURI().startsWith("/api/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //인증 필요없는 경로는 패스
+        if(skipUrls.contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //accessToken 추출
+        String header = request.getHeader("Authorization");
+        if(header == null || !header.startsWith("Bearer ")) {
+            //AccessToken 없으면 인증 안 된 상태로 통과
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String accessToken = header.replace("Bearer ", "");
+
+        //accessToken이 없을 때 -> refreshToken 확인 후 재발급
+        Claims accessClaims = jwtProvider.getClaims(accessToken, true);
+        if(accessClaims == null) {
+            String refreshToken = cookieHelper.getCookieValue("refreshToekn", null);
+            if(refreshToken == null || refreshToken.isBlank()) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            accessClaims = reIssueAccessToken(refreshToken, request, response);
+        }
+
+        //accessToken으로 인증 정보 저장
+        if(accessClaims != null) {
+            setAuthentication(accessClaims);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private Claims reIssueAccessToken(String refreshToken, HttpServletRequest request, HttpServletResponse response) {
+        //refreshToken 추출 후 유효성 검사
+        Claims refreshClaims = jwtProvider.getClaims(refreshToken, false);
+        if(refreshClaims == null) return null;
+
+        //member 정보로 accessToken 재발급
+        Long memberId = refreshClaims.get("memberId", Long.class);
+        Member member = memberService.findById(memberId);
+        String newAccessToken = authService.reissueAccessToken(member);
+
+        //헤더 설정
+        response.setHeader("Authorization", "Bearer " + newAccessToken);
+
+        //새로 설정한 토큰의 Claim 추출
+        return jwtProvider.getClaims(newAccessToken, true);
+    }
+
+    private void setAuthentication(Claims claims) {
+        //accessToken으로 UserDetails 객체 생성
+        CustomUserDetails userDetails = new CustomUserDetails(
+                ((Number) claims.get("id")).longValue(),
+                (String) claims.get("name"),
+                (String) claims.get("role"),
+                (String) claims.get("status")
+        );
+
+        //Spring Security 인증 토큰 생성
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        //SecurityContext에 인증 정보 저장
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -1,27 +1,114 @@
 package com.back.global.security;
 
+import com.back.global.response.ApiResponse;
+import com.back.standard.json.JsonUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                //요청에 대한 권한 설정
                 .authorizeHttpRequests(auth -> auth
+                        //누구나 접근 가능
+                        .requestMatchers("/api/*/test/public").permitAll()
+
+                        //인증된 사용자만 접근 가능
+                        .requestMatchers("/api/*/test/auth").authenticated()
+                        .requestMatchers("/api/*/test/auth/me").authenticated()
+
+                        //프리랜서만 접근 가능
+                        .requestMatchers("/api/*/test/auth/freelancer").hasRole("FREELANCER")
+
+                        //클라이언트만 접근 가능
+                        .requestMatchers("/api/*/test/auth/client").hasRole("CLIENT")
+
+                        //관리자만 접근 가능
+                        .requestMatchers("/api/*/test/auth/admin").hasRole("ADMIN")
+
+                        //그 외 요청은 인증 필요없음
                         .anyRequest().permitAll()
+                )
+
+                // REST API용 Security 기본 기능 비활성화
+                .csrf(AbstractHttpConfigurer::disable) // csrf 보호기능 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 기본 로그인 폼 비활성
+                .logout(AbstractHttpConfigurer::disable) // 로그아웃 기능 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+                .sessionManagement(AbstractHttpConfigurer::disable) // 세션 관리 비활성화
+
+                //jwt 인증 필터 추가
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+                //인증/인가 예외 처리
+                .exceptionHandling(
+                exceptionHandling -> exceptionHandling
+                        //인증 실패
+                        .authenticationEntryPoint(
+                                (request, response, authException) -> {
+                                    response.setContentType("application/json;charset=UTF-8");
+
+                                    response.setStatus(401);
+                                    response.getWriter().write(
+                                            JsonUtil.toString(
+                                                    new ApiResponse<Void>(
+                                                            "401-1",
+                                                            "로그인 후 이용해주세요."
+                                                    )
+                                            )
+                                    );
+                                }
+                        )
+                        //권한 부족
+                        .accessDeniedHandler(
+                                (request, response, accessDeniedException) -> {
+                                    response.setContentType("application/json;charset=UTF-8");
+
+                                    response.setStatus(403);
+                                    response.getWriter().write(
+                                            JsonUtil.toString(
+                                                    new ApiResponse<Void>(
+                                                            "403-1",
+                                                            "권한이 없습니다."
+                                                    )
+                                            )
+                                    );
+                                }
+                        )
                 );
+
         return http.build();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        //cors 설정
+        configuration.setAllowedOrigins(List.of("http://localhost:3000")); // 허용할 출처(origin)
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE")); // 허용할 메서드
+        configuration.setAllowCredentials(true); //인증 정보를 포함한 요청(쿠키, 헤더) 허용 여부
+        configuration.setAllowedHeaders(List.of("*")); //허용할 헤더 (* → 모든 헤더 허용)
+
+        //설정을 특정 경로 패턴에 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+
+        return source;
     }
 }

--- a/backend/src/main/java/com/back/global/security/annotation/CheckActive.java
+++ b/backend/src/main/java/com/back/global/security/annotation/CheckActive.java
@@ -1,0 +1,11 @@
+package com.back.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckActive {
+}

--- a/backend/src/main/java/com/back/global/security/annotation/OnlyActiveMember.java
+++ b/backend/src/main/java/com/back/global/security/annotation/OnlyActiveMember.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CheckActive {
+public @interface OnlyActiveMember {
 }

--- a/backend/src/main/java/com/back/standard/json/JsonUtil.java
+++ b/backend/src/main/java/com/back/standard/json/JsonUtil.java
@@ -1,0 +1,19 @@
+package com.back.standard.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonUtil {
+    public static ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String toString(Object obj) {
+        return toString(obj, null);
+    }
+
+    public static String toString(Object obj, String defaultValue) {
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+}

--- a/backend/src/test/java/com/back/domain/member/member/controller/AuthTestControllerTest.java
+++ b/backend/src/test/java/com/back/domain/member/member/controller/AuthTestControllerTest.java
@@ -1,0 +1,226 @@
+package com.back.domain.member.member.controller;
+
+import com.back.domain.member.member.service.MemberService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthTestControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private MemberService memberService;
+
+    // ---------- public(성공) ----------
+    @Test
+    @DisplayName("Public 성공 - 누구나 가능")
+    void t1_public() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/public"))
+                .andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(AuthTestController.class))
+                .andExpect(handler().methodName("publicEndpoint"))
+
+                //상태 코드 확인
+                .andExpect(status().isOk())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("누구나 접근 가능"));
+    }
+
+
+
+    // ---------- auth(성공 / 실패-인증X / 실패-활성X) ----------
+    @Test
+    @WithUserDetails("client1")
+    @DisplayName("Auth 성공 - 인증 + 활성 계정")
+    void t2_auth() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth"))
+                .andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(AuthTestController.class))
+                .andExpect(handler().methodName("authenticatedUserEndpoint"))
+
+                //상태 코드 확인
+                .andExpect(status().isOk())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value(Matchers.containsString("인증된 사용자 접근 성공")))
+                .andExpect(jsonPath("$.data.name").value("클라이언트1"))
+                .andExpect(jsonPath("$.data.role").value("CLIENT"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("Auth 실패 - 인증되지 않은 사용자")
+    void t3_auth_fail_noLogin() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth"))
+                .andDo(print());
+
+        resultActions
+                //상태 코드 확인
+                .andExpect(status().isUnauthorized())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("401-1"))
+                .andExpect(jsonPath("$.msg").value("로그인 후 이용해주세요."));
+    }
+
+    @Test
+    @WithUserDetails("client2") // INACTIVE 계정
+    @DisplayName("Auth 실패 - 비활성 계정")
+    void t4_auth_fail_Inactive() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth"))
+                .andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(AuthTestController.class))
+                .andExpect(handler().methodName("authenticatedUserEndpoint"))
+                
+                //상태 코드 확인
+                .andExpect(status().isForbidden())
+                
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("403-2"))
+                .andExpect(jsonPath("$.msg").value("비활성 계정입니다."));
+    }
+
+
+
+    // ---------- client 테스트 (성공 / 실패-인증X / 실패-권한X / 실패-활성X) ----------
+    @Test
+    @WithUserDetails("client1")
+    @DisplayName("Client 성공")
+    void t5_client() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth/client"))
+                .andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(AuthTestController.class))
+                .andExpect(handler().methodName("clientEndpoint"))
+                
+                //상태 코드 확인
+                .andExpect(status().isOk())
+                
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("클라이언트 접근 성공"))
+                .andExpect(jsonPath("$.data.name").value("클라이언트1"))
+                .andExpect(jsonPath("$.data.role").value("CLIENT"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("Client 실패 - 인증되지 않은 사용자")
+    void t6_client_fail_noLogin() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth/client"))
+                .andDo(print());
+
+        resultActions
+                //상태 코드 확인
+                .andExpect(status().isUnauthorized())
+                
+                .andExpect(jsonPath("$.resultCode").value("401-1"))
+                .andExpect(jsonPath("$.msg").value("로그인 후 이용해주세요."));
+    }
+
+    @Test
+    @WithUserDetails("freelancer1")
+    @DisplayName("Client 실패 - 다른 역할")
+    void t7_client_fail_role() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth/client"))
+                .andDo(print());
+
+        resultActions
+                //상태 코드 확인
+                .andExpect(status().isForbidden())
+                
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("403-1"))
+                .andExpect(jsonPath("$.msg").value("권한이 없습니다."));
+    }
+
+    @Test
+    @WithUserDetails("client2")
+    @DisplayName("Client 실패 - 비활성 계정")
+    void t8_client_fail_inactive() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth/client"))
+                .andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(AuthTestController.class))
+                .andExpect(handler().methodName("clientEndpoint"))
+
+                //상태 코드 확인
+                .andExpect(status().isForbidden())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("403-2"))
+                .andExpect(jsonPath("$.msg").value("비활성 계정입니다."));
+    }
+
+    // ---------- Me 테스트 (성공 / 실패-인증X / 실패-활성X) ----------
+    @Test
+    @WithUserDetails("client1")
+    @DisplayName("내 정보 조회 성공")
+    void t9_me_success() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth/me"))
+                .andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(AuthTestController.class))
+                .andExpect(handler().methodName("myInfo"))
+
+                //상태 코드 확인
+                .andExpect(status().isOk())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("내 정보 조회 성공"))
+                .andExpect(jsonPath("$.data.name").value("클라이언트1"));
+    }
+    
+    @Test
+    @DisplayName("내 정보 조회 실패 - 인증되지 않은 사용자")
+    void t10_me_fail_noLogin() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/api/v1/test/auth/me"))
+                .andDo(print());
+
+        resultActions
+                //상태 코드 확인
+                .andExpect(status().isUnauthorized())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("401-1"))
+                .andExpect(jsonPath("$.msg").value("로그인 후 이용해주세요."));
+    }
+}

--- a/backend/src/test/java/com/back/domain/member/member/controller/AuthTestControllerTest.java
+++ b/backend/src/test/java/com/back/domain/member/member/controller/AuthTestControllerTest.java
@@ -18,6 +18,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
 
+/**
+ * 인증/인가 기능 임시 테스트용 컨트롤러입니다.
+ *
+ * - 구현한 인증/인가 기능을 테스트하기 위함
+ * - 테스트 케이스 작성 예시를 제공하기 위함
+ *
+ * 개발 완료 후에는 `AuthTestController`와 함께 제거해야 합니다.
+ */
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc


### PR DESCRIPTION
### 🚀 작업 내용
- AccessToken 만료 시 RefreshToken 기반 자동 재발급 로직 구현
  - `JwtAuthenticationFilter`에서 AccessToken 검증 후 만료 시 RefreshToken 확인 후 재발급
  - `CustomUserDetails`로 SecurityContext에 인증 정보 저장
  - 인증 필요 없는 URI는 `skipUrls`로 관리
- 테스트용 `AuthTestController` 및 인증/인가 시나리오 테스트 작성
- 사용자 상태(active) 확인용 커스텀 어노테이션 `@CheckActive` 및 Aspect 구현
- JwtProvider 개선
  - Key 생성 로직 추출
  - Claims 추출 메서드 추가
  - 토큰 유효성 검증 메서드 구현

### 🛠 변경 파일
- `member/member/dto/MemberDto` : 회원 정보 DTO 수정 (생성일 삭제)
- `member/member/controller/AuthTestController` : 인증/인가 테스트용 컨트롤러
- `member/member/service/AuthService`, `MemberService` : accessToken 재발급, findById 로직 추가
- `global/jwt/JwtProvider` : Key 생성, Claims 추출, 토큰 유효성 검증 메서드 추가
- `global/security/SecurityConfig`, `CustomUserDetails`, `JwtAuthenticationFilter` : 인증/인가 관련 구현
- `global/security/CustomUserDetailsService` : 테스트에서 `@WithUserDetails` 사용하기 위함
- `global/security/annotation/CheckActive` : active 상태 확인 어노테이션
- `global/aspect/CheckActiveAspect` : `@CheckActive` 적용 Aspect
- `global/app/AppConfig` : PasswordEncoder, ObjectMapper 등 빈 등록
- `standard/json/JsonUtil` : 인증/인가 예외 처리 시 Json 응답 유틸
- `member/member/controller/AuthTestControllerTest` : 인증/인가 테스트

### ✅ 체크리스트
- [x] 코드 빌드 성공
- [x] 테스트 통과
- [ ] 문서 업데이트
- [ ] 형식/스타일 가이드 준수
- [ ] 필요 시 마이그레이션/DB 변경 적용
- [ ] 제출 전 코드 포맷팅(ctrl + alt + L) 사용

### 🔗 관련 이슈
- 이슈 번호: #37
- 참고 링크: 6주차 개인별 ActionPlan - 인증/인가 페이지

### 💡 추가 설명 / 주의 사항
- 인증/인가를 구현할 시 참고해야 하는 파일 : `AuthTestController`, `SecurityConfig`, `AuthTestControllerTest`
  - 인증/인가 구현 테스트 및 예시 작성용이니 참고하시면 될 것 같습니다.
- 활성/비활성화 상태 확인은 많이 사용할 것 같아 어노테이션을 사용하여 Aspect로 분리함
  - `@CheckActive` 어노테이션 붙이면 비활성화 계정일 시 예외 처리함 
- `CustomUserDetailsService` 구현은 테스트에서 `@WithUserDetails`를 사용하기 위함
  - 실제 운영/개발 환경에서는 사용되지 않습니다. 
- 순환 참조 문제 발생으로 인해 AppConfig로 PasswordEncoder 옮김
- DTO 사이즈 설정 오류로 프리랜서 로그인 실패 문제 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JWT-based authentication with automatic access-token renewal from refresh tokens, JSON 401/403 responses, role-based access rules, CORS for http://localhost:3000, and test endpoints under /api/v1/test.
  - Active-account enforcement for secured endpoints.

- Refactor
  - Member API response: role/status now strings; createDate removed.

- Improvements
  - Broadened input limits: name/username up to 20 chars; passwords up to 20 chars.

- Tests
  - Integration tests covering public, authenticated, role-restricted, and inactive-user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->