### PR TITLE
✨ Feat[BE](Application): 지원서(Application) CRUD 기능 구현 

### DIFF
--- a/backend/src/main/java/com/back/domain/application/application/constant/ApplicationStatus.java
+++ b/backend/src/main/java/com/back/domain/application/application/constant/ApplicationStatus.java
@@ -1,0 +1,16 @@
+package com.back.domain.application.application.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum ApplicationStatus {
+    WAIT("대기"),
+    ACCEPT("수락"),
+    DENIED("거절");
+
+    private final String label;
+
+    ApplicationStatus(String label) {
+        this.label = label;
+    }
+}

--- a/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
+++ b/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
@@ -1,6 +1,7 @@
 package com.back.domain.application.application.controller;
 
 import com.back.domain.application.application.dto.ApplicationDto;
+import com.back.domain.application.application.dto.ApplicationModifyReqBody;
 import com.back.domain.application.application.dto.ApplicationWriteReqBody;
 import com.back.domain.application.application.entity.Application;
 import com.back.domain.application.application.service.ApplicationService;
@@ -24,7 +25,8 @@ public class ApiV1ApplicationController {
     private final ProjectService ProjectService;
     private final MemberService memberService;
     private final FreelancerService freelancerService;
-    // TODO: 등록
+
+    // 등록
     @PostMapping
     @Transactional
     public ApiResponse<ApplicationDto> create(
@@ -47,7 +49,37 @@ public class ApiV1ApplicationController {
         );
     }
 
-    // TODO: 수정
+    // 수정
+    @PatchMapping("/{id}")
+    @Transactional
+    public ApiResponse<ApplicationDto> update(
+            @PathVariable long projectId,
+            @PathVariable long id,
+            @Valid @RequestBody ApplicationModifyReqBody reqBody
+            ) {
+        // TODO: 권한 체크
+        // 임시로 프로젝트 등록 유저 정보 받아오기
+//        Member member = memberService.findByUsername("client1").get();
+//        Client client = member.getClient();
+
+//        Project project = ProjectService.findById(projectId);
+
+        // 수정 권한 체크
+//        if (!project.getClient().equals(client)) {
+//            throw new ServiceException("404-1", "지원서 수정 권한이 없습니다.");
+//        }
+
+        Application application = applicationService.findById(id);
+
+        applicationService.update(application, reqBody.status());
+
+
+        return new ApiResponse<>(
+                "200-1",
+                "%d번 지원서가 수정되었습니다.".formatted(application.getId()),
+                new ApplicationDto(application)
+        );
+    }
 
     // TODO: 삭제
 

--- a/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
+++ b/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
@@ -1,0 +1,57 @@
+package com.back.domain.application.application.controller;
+
+import com.back.domain.application.application.dto.ApplicationDto;
+import com.back.domain.application.application.dto.ApplicationWriteReqBody;
+import com.back.domain.application.application.entity.Application;
+import com.back.domain.application.application.service.ApplicationService;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.freelancer.freelancer.service.FreelancerService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.domain.project.project.entity.Project;
+import com.back.domain.project.project.service.ProjectService;
+import com.back.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/projects/{projectId}/applications")
+@RequiredArgsConstructor
+public class ApiV1ApplicationController {
+    private final ApplicationService applicationService;
+    private final ProjectService ProjectService;
+    private final MemberService memberService;
+    private final FreelancerService freelancerService;
+    // TODO: 등록
+    @PostMapping
+    @Transactional
+    public ApiResponse<ApplicationDto> create(
+            @PathVariable long projectId,
+            @Valid @RequestBody ApplicationWriteReqBody reqBody
+            ) {
+        // 임시로 회원 하나의 freelancer 정보 넣음
+        Member freelancerMember1 = memberService.findByUsername("freelancer1").get();
+        Freelancer freelancer = freelancerService.findById(freelancerMember1.getId());
+
+        // 프로젝트 정보 받아오기
+        Project project = ProjectService.findById(projectId);
+
+        Application application = applicationService.create(reqBody, freelancer, project);
+
+        return new ApiResponse<>(
+                "201-1",
+                "%d번 지원서가 생성되었습니다.".formatted(application.getId()),
+                new ApplicationDto(application)
+        );
+    }
+
+    // TODO: 수정
+
+    // TODO: 삭제
+
+    // TODO: 조회
+    // 클라이언트가 프로젝트의 지원 보기
+    // 프리랜서가 자신의 지원 보기
+}

--- a/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
+++ b/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/projects/{projectId}/applications")
 @RequiredArgsConstructor
@@ -92,7 +94,58 @@ public class ApiV1ApplicationController {
         return new ApiResponse<>("200-1", "%d번 지원서가 삭제되었습니다.".formatted(id));
     }
 
-    // TODO: 조회
+    // 조회
+    // 단건 조회
+    @GetMapping("/{id}")
+    @Transactional(readOnly = true)
+    public ApiResponse<ApplicationDto> get(@PathVariable long projectId, @PathVariable long id) {
+        Application application = applicationService.findById(id);
+
+        return new ApiResponse<>(
+                "200-1",
+                "%d번 지원서가 단건 조회되었습니다.".formatted(id),
+                new ApplicationDto(application)
+                );
+    }
     // 클라이언트가 프로젝트의 지원 보기
+    @GetMapping
+    @Transactional(readOnly = true)
+    public ApiResponse<List<ApplicationDto>> getAll(@PathVariable long projectId) {
+        Project project = ProjectService.findById(projectId);
+        List<Application> applicationList = applicationService.findAllByProject(project);
+
+        // List<ApplicationDto>로 넣어주기
+        List<ApplicationDto> applicationDtoList = applicationList.stream()
+                .map(ApplicationDto::new)
+                .toList();
+
+        return new ApiResponse<>(
+                "200-1",
+                "%d번 프로젝트의 지원서가 조회되었습니다.".formatted(projectId),
+                applicationDtoList
+        );
+    }
     // 프리랜서가 자신의 지원 보기
+    @GetMapping("/me") // 임시로 매핑한 상태며 RESTful 한 URI를 위해 Freelancer로 옮기거나 수정될 예정
+    @Transactional(readOnly = true)
+    public ApiResponse<List<ApplicationDto>> getAllMe(
+            @PathVariable long projectId // 이것도 안쓰임
+    ) {
+        // 임시로 회원 하나의 freelancer 정보 불러옴
+        Member freelancerMember1 = memberService.findByUsername("freelancer1").get();
+        Freelancer freelancer = freelancerService.findById(freelancerMember1.getId());
+
+        List<Application> applicationList = applicationService.findAllByFreeLancer(freelancer);
+
+        // List<ApplicationDto>로 넣어주기
+        List<ApplicationDto> applicationDtoList = applicationList.stream()
+                .map(ApplicationDto::new)
+                .toList();
+
+        return new ApiResponse<>(
+                "200-1",
+                "%d번 프리랜서의 지원서가 조회되었습니다.".formatted(freelancer.getId()),
+                applicationDtoList
+        );
+    }
 }

--- a/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
+++ b/backend/src/main/java/com/back/domain/application/application/controller/ApiV1ApplicationController.java
@@ -81,7 +81,16 @@ public class ApiV1ApplicationController {
         );
     }
 
-    // TODO: 삭제
+    // 삭제
+    @DeleteMapping("/{id}")
+    @Transactional
+    public ApiResponse<Void> delete(@PathVariable long projectId, @PathVariable long id) {
+        Application application = applicationService.findById(id);
+
+        applicationService.delete(application);
+
+        return new ApiResponse<>("200-1", "%d번 지원서가 삭제되었습니다.".formatted(id));
+    }
 
     // TODO: 조회
     // 클라이언트가 프로젝트의 지원 보기

--- a/backend/src/main/java/com/back/domain/application/application/dto/ApplicationDto.java
+++ b/backend/src/main/java/com/back/domain/application/application/dto/ApplicationDto.java
@@ -1,0 +1,43 @@
+package com.back.domain.application.application.dto;
+
+import com.back.domain.application.application.constant.ApplicationStatus;
+import com.back.domain.application.application.entity.Application;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record ApplicationDto(
+        Long id,
+        BigDecimal estimatedPay,
+        String expectedDuration,
+        String workPlan,
+        String additionalRequest,
+        ApplicationStatus status,
+        String freelancerName,
+        Long freelancerId,
+        String projectTitle,
+        Long projectId,
+        String clientName,
+        Long clientId,
+        LocalDateTime createDate,
+        LocalDateTime modifyDate
+) {
+    public ApplicationDto(Application application) {
+        this (
+                application.getId(),
+                application.getEstimatedPay(),
+                application.getExpectedDuration(),
+                application.getWorkPlan(),
+                application.getAdditionalRequest(),
+                application.getStatus(),
+                application.getFreelancer().getMember().getName(),
+                application.getFreelancer().getMember().getId(),
+                application.getProject().getTitle(),
+                application.getProject().getId(),
+                application.getProject().getClient().getMember().getName(),
+                application.getProject().getClient().getMember().getId(),
+                application.getCreateDate(),
+                application.getModifyDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/domain/application/application/dto/ApplicationModifyReqBody.java
+++ b/backend/src/main/java/com/back/domain/application/application/dto/ApplicationModifyReqBody.java
@@ -1,0 +1,10 @@
+package com.back.domain.application.application.dto;
+
+import com.back.domain.application.application.constant.ApplicationStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ApplicationModifyReqBody(
+        @NotNull(message = "지원서 상태값은 필수입니다.")
+        ApplicationStatus status
+) {
+}

--- a/backend/src/main/java/com/back/domain/application/application/dto/ApplicationWriteReqBody.java
+++ b/backend/src/main/java/com/back/domain/application/application/dto/ApplicationWriteReqBody.java
@@ -1,0 +1,24 @@
+package com.back.domain.application.application.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record ApplicationWriteReqBody(
+        @NotNull(message = "예상 급여는 필수입니다.")
+        @DecimalMin(value = "0", inclusive = false, message = "예상 급여는 0보다 커야 합니다.")
+        BigDecimal estimatedPay,
+
+        @NotBlank(message = "예산 기간은 필수입니다.")
+        String expectedDuration,
+
+        @NotBlank(message = "작업 계획은 필수입니다.")
+        String workPlan,
+
+        @NotBlank(message = "추가 요청사항은 필수입니다.")
+        String additionalRequest
+) {
+
+}

--- a/backend/src/main/java/com/back/domain/application/application/entity/Application.java
+++ b/backend/src/main/java/com/back/domain/application/application/entity/Application.java
@@ -50,4 +50,8 @@ public class Application extends BaseEntity {
         this.project = project;
         this.client = project.getClient();
     }
+
+    public void modifyStatus(ApplicationStatus status) {
+        this.status = status;
+    }
 }

--- a/backend/src/main/java/com/back/domain/application/application/entity/Application.java
+++ b/backend/src/main/java/com/back/domain/application/application/entity/Application.java
@@ -1,0 +1,53 @@
+package com.back.domain.application.application.entity;
+
+import com.back.domain.application.application.constant.ApplicationStatus;
+import com.back.domain.application.application.dto.ApplicationWriteReqBody;
+import com.back.domain.client.client.entity.Client;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.project.project.entity.Project;
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor
+public class Application extends BaseEntity {
+    private BigDecimal estimatedPay;
+    private String expectedDuration;
+    private String workPlan;
+    private String additionalRequest;
+    private ApplicationStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "freelancer_id")
+    private Freelancer freelancer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    // Project가 이미 client를 가지고 있는데 굳이 또 넣어야하나?
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id")
+    private Client client;
+
+    public Application(ApplicationWriteReqBody reqBody, Freelancer freelancer, Project project) {
+        this.estimatedPay = reqBody.estimatedPay();
+        this.expectedDuration = reqBody.expectedDuration();
+        this.workPlan = reqBody.workPlan();
+        this.additionalRequest = reqBody.additionalRequest();
+        this.status = ApplicationStatus.WAIT;
+        this.freelancer = freelancer;
+        this.project = project;
+        this.client = project.getClient();
+    }
+}

--- a/backend/src/main/java/com/back/domain/application/application/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/back/domain/application/application/repository/ApplicationRepository.java
@@ -1,0 +1,12 @@
+package com.back.domain.application.application.repository;
+
+import com.back.domain.application.application.entity.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    Optional<Application> findFirstByOrderByIdDesc();
+}

--- a/backend/src/main/java/com/back/domain/application/application/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/back/domain/application/application/repository/ApplicationRepository.java
@@ -1,12 +1,18 @@
 package com.back.domain.application.application.repository;
 
 import com.back.domain.application.application.entity.Application;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.project.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
     Optional<Application> findFirstByOrderByIdDesc();
+
+    List<Application> findAllByProject(Project project);
+    List<Application> findAllByFreelancer(Freelancer freelancer);
 }

--- a/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
@@ -1,0 +1,27 @@
+package com.back.domain.application.application.service;
+
+import com.back.domain.application.application.dto.ApplicationWriteReqBody;
+import com.back.domain.application.application.entity.Application;
+import com.back.domain.application.application.repository.ApplicationRepository;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.project.project.entity.Project;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+    private final ApplicationRepository applicationRepository;
+
+    public Application create(ApplicationWriteReqBody reqBody, Freelancer freelancer, Project project) {
+        Application application = new Application(reqBody, freelancer, project);
+
+        return applicationRepository.save(application);
+    }
+
+    public Optional<Application> findLatest() {
+        return applicationRepository.findFirstByOrderByIdDesc();
+    }
+}

--- a/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
@@ -15,6 +15,10 @@ import java.util.Optional;
 public class ApplicationService {
     private final ApplicationRepository applicationRepository;
 
+    public long count() {
+        return applicationRepository.count();
+    }
+
     public Application create(ApplicationWriteReqBody reqBody, Freelancer freelancer, Project project) {
         Application application = new Application(reqBody, freelancer, project);
 

--- a/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
@@ -40,4 +40,8 @@ public class ApplicationService {
     public void update(Application application, ApplicationStatus status) {
         application.modifyStatus(status);
     }
+
+    public void delete(Application application) {
+        applicationRepository.delete(application);
+    }
 }

--- a/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
@@ -10,6 +10,7 @@ import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -43,5 +44,13 @@ public class ApplicationService {
 
     public void delete(Application application) {
         applicationRepository.delete(application);
+    }
+
+    public List<Application> findAllByProject(Project project) {
+        return applicationRepository.findAllByProject(project);
+    }
+
+    public List<Application> findAllByFreeLancer(Freelancer freelancer) {
+        return applicationRepository.findAllByFreelancer(freelancer);
     }
 }

--- a/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
@@ -1,10 +1,12 @@
 package com.back.domain.application.application.service;
 
+import com.back.domain.application.application.constant.ApplicationStatus;
 import com.back.domain.application.application.dto.ApplicationWriteReqBody;
 import com.back.domain.application.application.entity.Application;
 import com.back.domain.application.application.repository.ApplicationRepository;
 import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.project.project.entity.Project;
+import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,5 +29,15 @@ public class ApplicationService {
 
     public Optional<Application> findLatest() {
         return applicationRepository.findFirstByOrderByIdDesc();
+    }
+
+    public Application findById(long id) {
+        return applicationRepository.findById(id).orElseThrow(
+                () -> new ServiceException("401-1", "해당 지원서가 존재하지 않습니다.")
+        );
+    }
+
+    public void update(Application application, ApplicationStatus status) {
+        application.modifyStatus(status);
     }
 }

--- a/backend/src/main/java/com/back/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/com/back/global/initdata/BaseInitData.java
@@ -1,11 +1,17 @@
 package com.back.global.initdata;
 
+import com.back.domain.application.application.dto.ApplicationWriteReqBody;
+import com.back.domain.application.application.entity.Application;
+import com.back.domain.application.application.service.ApplicationService;
 import com.back.domain.client.client.entity.Client;
 import com.back.domain.client.client.service.ClientService;
 import com.back.domain.common.interest.service.InterestService;
 import com.back.domain.common.skill.service.SkillService;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.freelancer.freelancer.service.FreelancerService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
+import com.back.domain.project.project.entity.Project;
 import com.back.domain.project.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +38,8 @@ public class BaseInitData {
     private final ProjectService projectService;
     private final SkillService skillService;
     private final InterestService interestService;
+    private final ApplicationService applicationService;
+    private final FreelancerService freelancerService;
 
 
     @Bean
@@ -40,6 +48,7 @@ public class BaseInitData {
             self.addMember();
             self.addSkillAndInterest();
             self.addProject();
+            self.addApplication();
         };
     }
 
@@ -134,6 +143,56 @@ public class BaseInitData {
                 LocalDateTime.now().plusMonths(3),
                 skillIds3,
                 interestIds3
+        );
+    }
+
+    @Transactional
+    public void addApplication() {
+        if (applicationService.count() > 0) return;
+
+        // 프리랜서 회원 조회
+        Member freelancerMember1 = memberService.findByUsername("freelancer1").get();
+        Freelancer freelancer1 = freelancerService.findById(freelancerMember1.getId());
+        Member freelancerMember2 = memberService.findByUsername("freelancer2").get();
+        Freelancer freelancer2 = freelancerService.findById(freelancerMember2.getId());
+
+        // 프로젝트 조회
+        Project project1 = projectService.findById(1);
+        Project project2 = projectService.findById(2);
+        Project project3 = projectService.findById(3);
+
+        // 지원서 3개 생성
+        Application application1 = applicationService.create(
+                new ApplicationWriteReqBody(
+                        BigDecimal.valueOf(1_000_000),
+                        "1개월",
+                        "주 5일, 원격 근무",
+                        "추가 자료 없음"
+                ),
+                freelancer1,
+                project1
+        );
+
+        Application application2 = applicationService.create(
+                new ApplicationWriteReqBody(
+                        BigDecimal.valueOf(2_000_000),
+                        "2개월",
+                        "주 3일, 출근 근무",
+                        "디자인 자료 필요"
+                ),
+                freelancer1,
+                project2
+        );
+
+        Application application3 = applicationService.create(
+                new ApplicationWriteReqBody(
+                        BigDecimal.valueOf(2_500_000),
+                        "3개월",
+                        "주 4일, 혼합 근무",
+                        "기술 자료 요청"
+                ),
+                freelancer2,
+                project3
         );
     }
 }

--- a/backend/src/test/java/com/back/domain/application/application/controller/ApiV1ApplicationControllerTest.java
+++ b/backend/src/test/java/com/back/domain/application/application/controller/ApiV1ApplicationControllerTest.java
@@ -93,4 +93,23 @@ class ApiV1ApplicationControllerTest {
                 .andExpect(jsonPath("$.msg").value("%d번 지원서가 수정되었습니다.".formatted(application.getId())))
                 .andExpect(jsonPath("$.data.status").value("ACCEPT"));
     }
+
+    @Test
+    @DisplayName("지원서 삭제")
+    @WithMockUser(username = "freelancer1", roles = {"FREELANCER"})
+    void t3() throws Exception {
+        long id = 1;
+
+        ResultActions resultActions = mvc.perform(
+                delete(String.format("/api/v1/projects/1/applications/" + id))
+                        .with(csrf())
+        ).andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1ApplicationController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("%d번 지원서가 삭제되었습니다.".formatted(id)));
+    }
 }

--- a/backend/src/test/java/com/back/domain/application/application/controller/ApiV1ApplicationControllerTest.java
+++ b/backend/src/test/java/com/back/domain/application/application/controller/ApiV1ApplicationControllerTest.java
@@ -1,0 +1,68 @@
+package com.back.domain.application.application.controller;
+
+import com.back.domain.application.application.entity.Application;
+import com.back.domain.application.application.service.ApplicationService;
+import com.back.global.exception.ServiceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ApiV1ApplicationControllerTest {
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ApplicationService applicationService;
+
+    @Test
+    @DisplayName("지원서 등록")
+    @WithMockUser(username = "client1", roles = {"CLIENT"})
+    void t1() throws Exception {
+        ResultActions resultActions = mvc.perform(
+                post("/api/v1/projects/1/applications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content("""
+                        {
+                          "estimatedPay": 5000000,
+                          "expectedDuration": "3개월",
+                          "workPlan": "주 5일, 원격 근무로 진행하겠습니다.",
+                          "additionalRequest": "디자인 관련 자료를 미리 공유 부탁드립니다."
+                        }
+                    """)
+        ).andDo(print());
+
+        Application application = applicationService.findLatest().orElseThrow(
+                () -> new ServiceException("401-1", "지원서가 생성되지 않았습니다.")
+        );
+
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(handler().handlerType(ApiV1ApplicationController.class))
+                .andExpect(handler().methodName("create"))
+                .andExpect(jsonPath("$.resultCode").value("201-1"))
+                .andExpect(jsonPath("$.msg").value("%d번 지원서가 생성되었습니다.".formatted(application.getId())))
+                .andExpect(jsonPath("$.data.estimatedPay").value(application.getEstimatedPay()))
+                .andExpect(jsonPath("$.data.expectedDuration").value(application.getExpectedDuration()))
+                .andExpect(jsonPath("$.data.workPlan").value(application.getWorkPlan()))
+                .andExpect(jsonPath("$.data.additionalRequest").value(application.getAdditionalRequest()))
+                .andExpect(jsonPath("$.data.projectId").value(application.getId()))
+                .andExpect(jsonPath("$.data.freelancerName").value(application.getFreelancer().getMember().getName()));
+    }
+}

--- a/backend/src/test/java/com/back/domain/application/application/controller/ApiV1ApplicationControllerTest.java
+++ b/backend/src/test/java/com/back/domain/application/application/controller/ApiV1ApplicationControllerTest.java
@@ -2,6 +2,12 @@ package com.back.domain.application.application.controller;
 
 import com.back.domain.application.application.entity.Application;
 import com.back.domain.application.application.service.ApplicationService;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.freelancer.freelancer.service.FreelancerService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.domain.project.project.entity.Project;
+import com.back.domain.project.project.service.ProjectService;
 import com.back.global.exception.ServiceException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +20,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -29,6 +37,12 @@ class ApiV1ApplicationControllerTest {
     private MockMvc mvc;
     @Autowired
     private ApplicationService applicationService;
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private FreelancerService freelancerService;
+    @Autowired
+    private ProjectService projectService;
 
     @Test
     @DisplayName("지원서 등록")
@@ -111,5 +125,98 @@ class ApiV1ApplicationControllerTest {
                 .andExpect(handler().methodName("delete"))
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.msg").value("%d번 지원서가 삭제되었습니다.".formatted(id)));
+    }
+    @Test
+    @DisplayName("지원서 단건(상세) 조회")
+    @WithMockUser(username = "freelancer1", roles = {"FREELANCER"})
+    void t4() throws Exception {
+        long projectId = 1;
+        long id = 1;
+
+        ResultActions resultActions = mvc.perform(
+                get(String.format("/api/v1/projects/%d/applications/%d".formatted(projectId, id)))
+                        .with(csrf())
+        ).andDo(print());
+
+        Application application = applicationService.findById(id);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1ApplicationController.class))
+                .andExpect(handler().methodName("get"))
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("%d번 지원서가 단건 조회되었습니다.".formatted(id)))
+                .andExpect(jsonPath("$.data.estimatedPay").value(org.hamcrest.Matchers.closeTo(application.getEstimatedPay().doubleValue(), 0.01)))                .andExpect(jsonPath("$.data.expectedDuration").value(application.getExpectedDuration()))
+                .andExpect(jsonPath("$.data.workPlan").value(application.getWorkPlan()))
+                .andExpect(jsonPath("$.data.additionalRequest").value(application.getAdditionalRequest()))
+                .andExpect(jsonPath("$.data.projectId").value(application.getProject().getId()))
+                .andExpect(jsonPath("$.data.freelancerName").value(application.getFreelancer().getMember().getName()));
+    }
+
+    @Test
+    @DisplayName("지원서 조회 (작성자 기준)")
+    @WithMockUser(username = "freelancer1", roles = {"FREELANCER"})
+    void t5_getAllMe() throws Exception {
+        Member member = memberService.findByUsername("freelancer1").get();
+        Freelancer freelancer = freelancerService.findById(member.getId());
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/v1/projects/1/applications/me")
+                        .with(csrf())
+        ).andDo(print());
+
+        List<Application> applications = applicationService.findAllByFreeLancer(freelancer);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1ApplicationController.class))
+                .andExpect(handler().methodName("getAllMe"))
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("%d번 프리랜서의 지원서가 조회되었습니다.".formatted(freelancer.getId())));
+
+        for (int i = 0; i < applications.size(); i++) {
+            Application application = applications.get(i);
+            resultActions
+                    .andExpect(jsonPath("$.data[" + i + "].estimatedPay").value(org.hamcrest.Matchers.closeTo(application.getEstimatedPay().doubleValue(), 0.01)))
+                    .andExpect(jsonPath("$.data[" + i + "].expectedDuration").value(application.getExpectedDuration()))
+                    .andExpect(jsonPath("$.data[" + i + "].workPlan").value(application.getWorkPlan()))
+                    .andExpect(jsonPath("$.data[" + i + "].additionalRequest").value(application.getAdditionalRequest()))
+                    .andExpect(jsonPath("$.data[" + i + "].projectId").value(application.getProject().getId()))
+                    .andExpect(jsonPath("$.data[" + i + "].freelancerName").value(application.getFreelancer().getMember().getName()));
+        }
+    }
+
+    @Test
+    @DisplayName("지원서 조회 (프로젝트 기준)")
+    @WithMockUser(username = "client1", roles = {"CLIENT"})
+    void t6_getAllByProject() throws Exception {
+        long projectId = 1;
+        Project project = projectService.findById(projectId);
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/v1/projects/{projectId}/applications", projectId)
+                        .with(csrf())
+        ).andDo(print());
+
+        List<Application> applications = applicationService.findAllByProject(project);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1ApplicationController.class))
+                .andExpect(handler().methodName("getAll"))
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("%d번 프로젝트의 지원서가 조회되었습니다.".formatted(projectId)));
+
+        for (int i = 0; i < applications.size(); i++) {
+            Application application = applications.get(i);
+            resultActions
+                    .andExpect(jsonPath("$.data[" + i + "].estimatedPay").value(org.hamcrest.Matchers.closeTo(application.getEstimatedPay().doubleValue(), 0.01)))
+                    .andExpect(jsonPath("$.data[" + i + "].expectedDuration").value(application.getExpectedDuration()))
+                    .andExpect(jsonPath("$.data[" + i + "].workPlan").value(application.getWorkPlan()))
+                    .andExpect(jsonPath("$.data[" + i + "].additionalRequest").value(application.getAdditionalRequest()))
+                    .andExpect(jsonPath("$.data[" + i + "].projectId").value(application.getProject().getId()))
+                    .andExpect(jsonPath("$.data[" + i + "].freelancerName").value(application.getFreelancer().getMember().getName()));
+        }
+
     }
 }


### PR DESCRIPTION
### 🚀 작업 내용
- 지원서 작성, 조회, 수정, 삭제 기능 구현
- 수정의 경우 클라이언트가 자신의 프로젝트에서 받은 지원서의 상태(status)를 변경하는 기능
- 다건 조회의 경우 프리랜서가 자신이 등록한 모든 지원서를 보는 경우와 클라이언트가 자신의 특정 프로젝트에 등록된 지원서를 보는 경우로 나누어 구현

### ✅ 체크리스트
- [x] 코드 빌드 성공
- [x] 테스트 통과
- [x] 문서 업데이트
- [x] 형식/스타일 가이드 준수
- [x] 제출 전 코드 포맷팅(ctrl + alt + L) 사용

### 🔗 관련 이슈
- 이슈 번호: #42 
- 참고 링크: 설계 문서, 참고 자료

### 💡 추가 설명 / 주의 사항
- 인증인가 기능을 바탕으로 권한 확인 및 검증 기능 추가 예정
- 다건 조회의 경우 리스트 나열을 위한 단순화된 ApplicationSummaryDto 만들 예정