### PR TITLE
✨ Feat[BE](swagger): Swagger 의존성 추가

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     annotationProcessor("com.querydsl:querydsl-apt:${queryDslVersion}:jakarta")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/controller/ApiV1FreelancerController.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/controller/ApiV1FreelancerController.java
@@ -8,6 +8,10 @@ import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.freelancer.freelancer.service.FreelancerService;
 import com.back.global.response.ApiResponse;
 import com.back.standard.converter.FreelancerSearchConditionConverter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -25,14 +29,15 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name="ApiV1FreelancerController", description = "API 프리랜서 컨트롤러")
 @RequestMapping("/api/v1/freelancers")
-public class FreelancerController {
+public class ApiV1FreelancerController {
 
     private final FreelancerService freelancerService;
     private final FreelancerSearchConditionConverter converter;
 
-    // 프리랜서 정보 수정
     @PutMapping("/{id}")
+    @Operation(summary = "프리랜서 개인정보 수정")
     public ApiResponse<FreelancerUpdateResponse> updateFreelancer(@PathVariable Long id,
                                                                   @RequestBody FreelancerUpdateForm form) {
         Freelancer freelancer = freelancerService.updateFreelancer(
@@ -53,8 +58,8 @@ public class FreelancerController {
         );
     }
 
-    // 프리랜서 목록 조회
     @GetMapping
+    @Operation(summary = "프리랜서 목록 조회")
     public ApiResponse<Page<FreelancerSummary>> getFreelancers(
             @RequestParam(required = false) String careerLevel,
             @RequestParam(required = false) Float ratingAvg,

--- a/backend/src/main/java/com/back/domain/proposal/proposal/controller/ApiV1ProposalController.java
+++ b/backend/src/main/java/com/back/domain/proposal/proposal/controller/ApiV1ProposalController.java
@@ -8,6 +8,8 @@ import com.back.domain.proposal.proposal.dto.ProposalWriteReqBody;
 import com.back.domain.proposal.proposal.service.ProposalService;
 import com.back.global.response.ApiResponse;
 import com.back.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,16 +23,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-// 제안서 (클라이언트 -> 프리랜서) 컨트롤러
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/projects/{projectId}/proposals")
-public class ProposalController {
+@Tag(name="ApiV1ProposalController", description = "API 제안서(클라이언트 -> 프리랜서) 컨트롤러")
+public class ApiV1ProposalController {
 
     private final ProposalService proposalService;
     private final MemberService memberService;
 
     @GetMapping
+    @Operation(summary = "프로젝트에 해당하는 제안서 목록 조회")
     // NOTE : 권한 설정 및 DTO 데이터에 대한 변경 이후에 논의 필요함
     // 1. 프로젝트 작성자가 프로젝트에 해당하는 제안서를 모두 보려는 경우 -> 권한설정만 추가
     // 2. 프로젝트 상세보기에서 간략하게 제안서 목록을 보려는 경우 -> DTO 변경 필요
@@ -46,6 +49,7 @@ public class ProposalController {
     }
 
     @PostMapping
+    @Operation(summary = "프로젝트에 제안서 등록")
     public ApiResponse<ProposalDto> create(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long projectId,
@@ -63,6 +67,7 @@ public class ProposalController {
     }
 
     @GetMapping("/{proposalId}")
+    @Operation(summary = "프로젝트에 해당하는 특정 ID 제안서를 조회")
     public ApiResponse<ProposalDto> getProposal(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long projectId,
@@ -79,6 +84,7 @@ public class ProposalController {
     }
 
     @PatchMapping("/{proposalId}")
+    @Operation(summary = "프로젝트에 해당하는 특정 ID 제안서의 상태 변경")
     public ApiResponse<ProposalDto> updateState(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long projectId,
@@ -97,6 +103,7 @@ public class ProposalController {
     }
 
     @DeleteMapping("/{proposalId}")
+    @Operation(summary = "프로젝트에 해당하는 특정 ID 제안서 삭제")
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long projectId,

--- a/backend/src/main/java/com/back/global/springdoc/SpringDocConfig.java
+++ b/backend/src/main/java/com/back/global/springdoc/SpringDocConfig.java
@@ -1,0 +1,37 @@
+package com.back.global.springdoc;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "API 서버", version = "beta", description = "프리랜서 매칭 API 서버 문서입니다."))
+@SecurityScheme(
+        name = "bearerAuth",
+        type= SecuritySchemeType.HTTP,
+        bearerFormat="JWT",
+        scheme = "bearer"
+)
+public class SpringDocConfig {
+
+    @Bean
+    public GroupedOpenApi groupApiV1() {
+        return GroupedOpenApi.builder()
+                .group("apiV1") // 그룹이름
+                .pathsToMatch("/api/v1/**") // api/v1/ ** 경로 매칭
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi groupController() {
+        return GroupedOpenApi.builder()
+                .group("non-api") // 그룹이름
+                .pathsToExclude("/api/**") // api/ ** 경로 제외
+                .pathsToMatch("/**") // 모든 경로 포함
+                .build();
+    }
+}

--- a/backend/src/main/java/com/back/home/home/controller/HomeController.java
+++ b/backend/src/main/java/com/back/home/home/controller/HomeController.java
@@ -1,0 +1,27 @@
+package com.back.home.home.controller;
+
+import static java.net.InetAddress.getLocalHost;
+
+import java.net.InetAddress;
+import lombok.SneakyThrows;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @SneakyThrows
+    @GetMapping
+    public String main() {
+        InetAddress localHost = getLocalHost();
+
+        return """
+                <h1>API 서버</h1>
+                <p>Host Name: %s</p>
+                <p>Host Address: %s</p>
+                <div>
+                    <a href="/swagger-ui/index.html">API 문서로 이동</a>
+                </div>
+                """.formatted(localHost.getHostName(), localHost.getHostAddress());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,3 +28,7 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+
+#springDoc 설정
+springdoc:
+  default-produces-media-type: application/json;charset=UTF-8

--- a/backend/src/test/java/com/back/domain/freelancer/freelancer/controller/ApiV1FreelancerControllerTest.java
+++ b/backend/src/test/java/com/back/domain/freelancer/freelancer/controller/ApiV1FreelancerControllerTest.java
@@ -9,13 +9,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.back.domain.freelancer.freelancer.dto.FreelancerSearchCondition;
 import com.back.domain.freelancer.freelancer.dto.FreelancerSummary;
-import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.freelancer.freelancer.service.FreelancerService;
-import com.back.domain.member.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,14 +22,13 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpClientErrorException.BadRequest;
 
 
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-class FreelancerControllerTest {
+class ApiV1FreelancerControllerTest {
 
     @Autowired
     private MockMvc mvc;
@@ -51,7 +46,7 @@ class FreelancerControllerTest {
 
         resultActions
                 //실행처 확인
-                .andExpect(handler().handlerType(FreelancerController.class))
+                .andExpect(handler().handlerType(ApiV1FreelancerController.class))
                 .andExpect(handler().methodName("getFreelancers"))
 
                 //상태 코드 확인
@@ -138,7 +133,7 @@ class FreelancerControllerTest {
 
         resultActions
                 //실행처 확인
-                .andExpect(handler().handlerType(FreelancerController.class))
+                .andExpect(handler().handlerType(ApiV1FreelancerController.class))
                 .andExpect(handler().methodName("updateFreelancer"))
 
                 //상태 코드 확인

--- a/backend/src/test/java/com/back/domain/project/proposal/controller/ApiV1ProposalControllerTest.java
+++ b/backend/src/test/java/com/back/domain/project/proposal/controller/ApiV1ProposalControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.domain.proposal.proposal.constant.ProposalStatus;
-import com.back.domain.proposal.proposal.controller.ProposalController;
+import com.back.domain.proposal.proposal.controller.ApiV1ProposalController;
 import com.back.domain.proposal.proposal.dto.ProposalDto;
 import com.back.domain.proposal.proposal.service.ProposalService;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 @AutoConfigureMockMvc
 @Transactional
 @DisplayName("제안서 (클라이언트 -> 프리랜서) 컨트롤러 테스트")
-class ProposalControllerTest {
+class ApiV1ProposalControllerTest {
 
     @Autowired
     private MockMvc mvc;
@@ -56,7 +56,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("getProposals"))
                 .andExpect(status().isOk())
 
@@ -101,7 +101,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("getProposal"))
                 .andExpect(status().isOk())
 
@@ -133,7 +133,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("getProposal"))
                 .andExpect(status().isOk());
     }
@@ -152,7 +152,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("getProposal"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resultCode").value("400-1"))
@@ -174,7 +174,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("getProposal"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.resultCode").value("403-2"))
@@ -196,7 +196,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("getProposal"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.resultCode").value("403-2"))
@@ -224,7 +224,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("create"))
                 .andExpect(status().isCreated())
 
@@ -315,7 +315,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("create"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.resultCode").value("403-1"))
@@ -343,7 +343,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("create"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resultCode").value("400-2"))
@@ -371,7 +371,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("updateState"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200"))
@@ -402,7 +402,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("updateState"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.resultCode").value("403-2"))
@@ -430,7 +430,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("updateState"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resultCode").value("400-1"))
@@ -467,7 +467,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("updateState"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resultCode").value("400-3"))
@@ -488,7 +488,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("delete"))
                 .andExpect(status().isNoContent())
                 .andExpect(jsonPath("$.data").doesNotExist());
@@ -507,7 +507,7 @@ class ProposalControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(ProposalController.class))
+                .andExpect(handler().handlerType(ApiV1ProposalController.class))
                 .andExpect(handler().methodName("delete"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.resultCode").value("403-2"))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #67 , #68 버그제보

## ✅ 체크리스트
- ✔️ 코드 빌드 성공
- ✔️ 테스트 통과
- ❌ 문서 업데이트
- ✔️ 형식/스타일 가이드 준수
- ❌필요 시 마이그레이션/DB 변경 적용
- ✔️  제출 전 코드 포맷팅(ctrl + alt + L) 사용

## 📝작업 내용

Swagger 의존성 및 홈 컨트롤러 추가하였습니다.

#68 버그에대해 은주님에게 확인요청 할 예정입니다.

다른 컨트롤러도 `@Operation`, `@Tag`  작업 가능하나, 개개인의 swagger 학습 및 적용을 위해 남겨두었습니다.

<img width="1470" height="878" alt="image" src="https://github.com/user-attachments/assets/28ed7d2d-8615-4506-b4e6-850208621757" />

<img width="291" height="261" alt="image" src="https://github.com/user-attachments/assets/d3b6a8eb-bc9c-48fe-bc88-ed32052bb037" />





[수업 참고자료](https://www.slog.gg/p/14526#3%EB%B6%80-:-%EB%AC%B8%EC%84%9C-%EC%9E%90%EB%8F%99%ED%99%94-%EC%8B%9C%EC%9E%91)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced interactive API documentation (Swagger UI), including grouped views for v1 endpoints.
  * Added a simple home page showing server details with a quick link to the API docs.

* **Documentation**
  * Enriched API docs with clear tags and summaries across freelancer and proposal endpoints.
  * Documented bearer token authentication within the API docs.

* **Bug Fixes**
  * Corrected application configuration to ensure proper logging behavior and consistent JSON response media type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->