### PR TITLE
 ✨  Feat[BE](MemberWithdraw) : 회원 탈퇴 기능 구현

### DIFF
--- a/backend/src/main/java/com/back/domain/application/application/entity/Application.java
+++ b/backend/src/main/java/com/back/domain/application/application/entity/Application.java
@@ -6,10 +6,7 @@ import com.back.domain.client.client.entity.Client;
 import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.project.project.entity.Project;
 import com.back.global.jpa.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -25,6 +22,7 @@ public class Application extends BaseEntity {
     private String expectedDuration;
     private String workPlan;
     private String additionalRequest;
+    @Enumerated(EnumType.STRING)
     private ApplicationStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/back/domain/client/client/entity/Client.java
+++ b/backend/src/main/java/com/back/domain/client/client/entity/Client.java
@@ -1,14 +1,13 @@
 package com.back.domain.client.client.entity;
 
 import com.back.domain.member.member.entity.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
+import com.back.domain.project.project.entity.Project;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -34,6 +33,10 @@ public class Client {
     //읽기전용?
     private double ratingAvg;
 
+    //클라이언트 - 프로젝트
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Project> projects = new ArrayList<>();
+
     public Client(Member member) {
         this.member = member;
     }
@@ -58,5 +61,15 @@ public class Client {
     //이미 계산된 평가 평균을 소수점 첫째 자리까지 반올림하기 위한 메서드
     public void updateRatingAvg(double ratingAvg) {
         this.ratingAvg = Math.round(ratingAvg * 10.0) / 10.0;
+    }
+
+    //회원 탈퇴 처리
+    public void deleteInfo() {
+        this.companySize = null;
+        this.companyDescription = null;
+        this.representative = null;
+        this.businessNo = null;
+        this.companyPhone = null;
+        this.companyEmail = null;
     }
 }

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/entity/Freelancer.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/entity/Freelancer.java
@@ -1,26 +1,20 @@
 package com.back.domain.freelancer.freelancer.entity;
 
+import com.back.domain.application.application.entity.Application;
 import com.back.domain.common.skill.entity.Skill;
 import com.back.domain.freelancer.join.entity.FreelancerInterest;
 import com.back.domain.freelancer.join.entity.FreelancerSkill;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.proposal.proposal.entity.Proposal;
 import com.back.standard.converter.JsonConverter;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
@@ -58,6 +52,13 @@ public class Freelancer {
     @OneToMany(mappedBy = "freelancer", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FreelancerInterest> interests = new ArrayList<>();
 
+    //프리랜서와 지원서, 제안서 연결
+    @OneToMany(mappedBy = "freelancer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Application> applications = new ArrayList<>();
+
+    @OneToMany(mappedBy = "freelancer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Proposal> proposals = new ArrayList<>();
+
     public Freelancer(Member member) {
         this.member = member;
     }
@@ -92,5 +93,22 @@ public class Freelancer {
     //이미 계산된 평가 평균을 소수점 첫째 자리까지 반올림하기 위한 메서드
     public void updateRatingAvg(double ratingAvg) {
         this.ratingAvg = Math.round(ratingAvg * 10.0) / 10.0;
+    }
+
+    //회원 탈퇴
+    public void deleteInfo() {
+        this.job = null;
+        this.freelancerEmail = null;
+        this.comment = null;
+        this.career = null;
+        this.careerTotalYears = null;
+
+        if(skills != null && !skills.isEmpty()) {
+            skills.clear();
+        }
+
+        if(interests != null && !interests.isEmpty()) {
+            interests.clear();
+        }
     }
 }

--- a/backend/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -182,4 +182,14 @@ public class MemberController {
 
         return new ApiResponse<>("200-10", "내가 지원한 프로젝트 목록 조회 성공", applicationSummaries);
     }
+
+    @PatchMapping("/me/withdraw")
+    public ApiResponse<Void> withdrawMyAccount(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody MemberWithdrawReq reqBody
+    ) {
+        Member member = memberService.findById(user.getId());
+        memberService.withdrawMember(member, reqBody.password());
+        return new ApiResponse<>("200-11", "회원 탈퇴가 완료되었습니다.");
+    }
 }

--- a/backend/src/main/java/com/back/domain/member/member/dto/MemberWithdrawReq.java
+++ b/backend/src/main/java/com/back/domain/member/member/dto/MemberWithdrawReq.java
@@ -1,0 +1,6 @@
+package com.back.domain.member.member.dto;
+
+public record MemberWithdrawReq(
+        String password
+) {
+}

--- a/backend/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -105,4 +105,23 @@ public class Member extends BaseEntity {
     public boolean isFreelancer() {
         return role == Role.FREELANCER;
     }
+
+    //회원 탈퇴 처리
+    public void withdraw() {
+        this.username = null;
+        this.password = null;
+        this.email = null;
+        this.profileImgUrl = null;
+        this.name = "탈퇴한 회원입니다.";
+        this.deleteDate = LocalDateTime.now();
+        this.status = MemberStatus.WITHDRAWN;
+
+        if(freelancer != null) {
+            freelancer.deleteInfo();
+        }
+
+        if(client != null) {
+            client.deleteInfo();
+        }
+    }
 }

--- a/backend/src/main/java/com/back/domain/project/project/entity/Project.java
+++ b/backend/src/main/java/com/back/domain/project/project/entity/Project.java
@@ -1,7 +1,9 @@
 package com.back.domain.project.project.entity;
 
+import com.back.domain.application.application.entity.Application;
 import com.back.domain.client.client.entity.Client;
 import com.back.domain.project.project.constant.ProjectStatus;
+import com.back.domain.proposal.proposal.entity.Proposal;
 import com.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -41,7 +43,13 @@ public class Project extends BaseEntity {
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectInterest> projectInterests = new ArrayList<>();
 
+    //프로젝트 - 지원서, 제안서 추가
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Application> applications = new ArrayList<>();
 
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Proposal> proposals = new ArrayList<>();
+    
     public Project(
             Client client,
             String title,
@@ -87,5 +95,9 @@ public class Project extends BaseEntity {
         this.description = description;
         this.deadline = deadline;
         this.status = status;
+    }
+
+    public void updateStatus(ProjectStatus projectStatus) {
+        this.status = projectStatus;
     }
 }

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/*/members/password-update").authenticated()
                         .requestMatchers("/api/v1/members/me").authenticated() // 내 프로필 조회
                         .requestMatchers("/api/v1/members/me/profile").authenticated() // 내 프로필 수정
+                        .requestMatchers("/api/v1/members/me/withdraw").authenticated() // 내 프로필 수정
 
                         //평가 생성 및 수정은 인증된 사용자만 가능
                         .requestMatchers(HttpMethod.POST, "/api/v1/evaluations").authenticated()

--- a/backend/src/test/java/com/back/domain/evaluation/controller/EvalutionControllerTest.java
+++ b/backend/src/test/java/com/back/domain/evaluation/controller/EvalutionControllerTest.java
@@ -7,10 +7,8 @@ import com.back.domain.evaluation.entity.FreelancerEvaluation;
 import com.back.domain.evaluation.repository.FreelancerEvaluationRepository;
 import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.freelancer.freelancer.repository.FreelancerRepository;
-import com.back.domain.member.member.constant.Role;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
-import com.back.domain.project.project.constant.ProjectStatus;
 import com.back.domain.project.project.entity.Project;
 import com.back.domain.project.project.repository.ProjectRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,11 +64,11 @@ class EvaluationControllerTest {
     @BeforeEach
     void setUp() {
 
-        clientMember = new Member("CLIENT", "password1234", "김클라", "01012345678", "client@test.com");
+        clientMember = new Member(null, "CLIENT", "password1234", "김클라", "01012345678", "client@test.com");
         memberRepository.save(clientMember);
         Client savedClient = clientRepository.save(new Client(clientMember));
 
-        freelancerMember = new Member("FREELANCER", "password1234", "박프리", "01087654321", "freelancer@test.com");
+        freelancerMember = new Member(null, "FREELANCER", "password1234", "박프리", "01087654321", "freelancer@test.com");
         memberRepository.save(freelancerMember);
         freelancerRepository.save(new Freelancer(freelancerMember));
 

--- a/backend/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -103,7 +103,7 @@ public class MemberControllerTest {
     @DisplayName("회원가입 실패 : 이미 존재하는 회원")
     void t3_join_exception() throws Exception {
 
-        memberService.join("CLIENT", "유저new", "userNew", "1234", "1234", "test@test.com");
+        memberService.join(null, "CLIENT", "유저new", "userNew", "1234", "1234", "test@test.com");
 
         //이미 사용중인 아이디로 회원가입
         ResultActions resultActions = mvc.perform(post("/api/v1/members").contentType(MediaType.APPLICATION_JSON).content("""
@@ -503,5 +503,26 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[?(@.projectTitle == '%s')]".formatted(project.getTitle())).exists())
                 .andExpect(jsonPath("$.data[?(@.freelancerName == '%s')]".formatted(freelancer.getMember().getName())).exists());
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공")
+    @WithUserDetails("client1")
+    public void t19_updatePassword_exception() throws Exception {
+        ResultActions resultActions = mvc.perform(patch("/api/v1/members/me/withdraw").contentType(MediaType.APPLICATION_JSON).content("""
+                {
+                    "password": "1234"
+                }
+                """)).andDo(print());
+
+        resultActions
+                //실행처 확인
+                .andExpect(handler().handlerType(MemberController.class)).andExpect(handler().methodName("withdrawMyAccount"))
+
+                //상태코드 확인
+                .andExpect(status().isOk())
+
+                //응답 데이터 확인
+                .andExpect(jsonPath("$.resultCode").value("200-11")).andExpect(jsonPath("$.msg").value("회원 탈퇴가 완료되었습니다."));
     }
 }

--- a/backend/src/test/java/com/back/domain/member/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/back/domain/member/member/service/MemberServiceTest.java
@@ -1,0 +1,113 @@
+package com.back.domain.member.member.service;
+
+import com.back.domain.application.application.constant.ApplicationStatus;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.project.project.constant.ProjectStatus;
+import com.back.domain.proposal.proposal.constant.ProposalStatus;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@SpringBootTest
+@Transactional
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    // 프리랜서 탈퇴 성공 - WAIT 지원서, OPEN 프로젝트
+    @Test
+    @DisplayName("프리랜서 탈퇴 성공 - WAIT 지원서 삭제, 제안서 WAIT → DENIED")
+    void withdrawFreelancer_success() {
+        Member freelancerMember = memberService.findByUsername("freelancer3").get();
+
+        // DB 그대로 사용, 상태 변경 없음
+        assertThat(freelancerMember.getFreelancer().getApplications())
+                .allMatch(app -> app.getStatus() == ApplicationStatus.WAIT);
+        assertThat(freelancerMember.getFreelancer().getApplications())
+                .allMatch(app -> app.getProject().getStatus() == ProjectStatus.OPEN);
+
+        memberService.withdrawMember(freelancerMember, "1234");
+
+        // 탈퇴 후 상태 검증
+        assertThat(freelancerMember.getStatus().name()).isEqualTo("WITHDRAWN");
+
+        // 탈퇴 후 비식별화 검증 - Member
+        assertThat(freelancerMember.getUsername()).isNull();
+        assertThat(freelancerMember.getPassword()).isNull();
+        assertThat(freelancerMember.getEmail()).isNull();
+        assertThat(freelancerMember.getProfileImgUrl()).isNull();
+        assertThat(freelancerMember.getName()).isEqualTo("탈퇴한 회원입니다.");
+        assertThat(freelancerMember.getDeleteDate()).isNotNull();
+
+        // 탈퇴 후 비식별화 검증 - Freelancer
+        assertThat(freelancerMember.getFreelancer().getJob()).isNull();
+        assertThat(freelancerMember.getFreelancer().getFreelancerEmail()).isNull();
+        assertThat(freelancerMember.getFreelancer().getComment()).isNull();
+        assertThat(freelancerMember.getFreelancer().getCareer()).isNull();
+        assertThat(freelancerMember.getFreelancer().getCareerTotalYears()).isNull();
+        assertThat(freelancerMember.getFreelancer().getSkills()).isEmpty();
+        assertThat(freelancerMember.getFreelancer().getInterests()).isEmpty();
+
+        // 탈퇴 후 지원서 상태 검증
+        assertThat(freelancerMember.getFreelancer().getApplications())
+                .allMatch(app -> app.getStatus() != ApplicationStatus.WAIT);
+
+        // 탈퇴 후 제안서 상태 검증
+        assertThat(freelancerMember.getFreelancer().getProposals())
+                .allMatch(proposal -> proposal.getStatus() == ProposalStatus.DENIED);
+    }
+
+    // 클라이언트 탈퇴 성공 - 진행 중 프로젝트 없음
+    @Test
+    @DisplayName("클라이언트 탈퇴 성공 - 진행 중 프로젝트 없음")
+    void withdrawClient_success() {
+        Member clientMember = memberService.findByUsername("client3").get();
+
+        // DB 그대로 사용, 상태 변경 없음
+        assertThat(clientMember.getClient().getProjects())
+                .allMatch(project -> project.getStatus() == ProjectStatus.OPEN);
+
+        memberService.withdrawMember(clientMember, "1234");
+
+        // 탈퇴 후 검증
+        assertThat(clientMember.getStatus().name()).isEqualTo("WITHDRAWN");
+
+        // 탈퇴 후 비식별화 검증 - Member
+        assertThat(clientMember.getUsername()).isNull();
+        assertThat(clientMember.getPassword()).isNull();
+        assertThat(clientMember.getEmail()).isNull();
+        assertThat(clientMember.getProfileImgUrl()).isNull();
+        assertThat(clientMember.getName()).isEqualTo("탈퇴한 회원입니다.");
+        assertThat(clientMember.getDeleteDate()).isNotNull();
+
+        // 탈퇴 후 비식별화 검증 - Client
+        assertThat(clientMember.getClient().getCompanySize()).isNull();
+        assertThat(clientMember.getClient().getCompanyDescription()).isNull();
+        assertThat(clientMember.getClient().getRepresentative()).isNull();
+        assertThat(clientMember.getClient().getBusinessNo()).isNull();
+        assertThat(clientMember.getClient().getCompanyPhone()).isNull();
+        assertThat(clientMember.getClient().getCompanyEmail()).isNull();
+
+        // 탈퇴 후 프로젝트 상태 검증
+        clientMember.getClient().getProjects().forEach(project ->
+                assertThat(project.getStatus()).isEqualTo(ProjectStatus.CLOSED)
+        );
+
+        // 탈퇴 후 지원서 상태 검증
+        clientMember.getClient().getProjects().forEach(project ->
+                assertThat(project.getApplications())
+                        .allMatch(app -> app.getStatus() == ApplicationStatus.DENIED)
+        );
+
+        // 탈퇴 후 제안서 상태 검증
+        clientMember.getClient().getProjects().forEach(project ->
+                assertThat(project.getProposals())
+                        .allMatch(proposal -> proposal.getStatus() == ProposalStatus.DENIED)
+        );
+    }
+}


### PR DESCRIPTION
### 🚀 작업 내용
- 회원 탈퇴 기능 구현
- 구현 방향 및 참고 사항:
  - **비밀번호 확인** 후 탈퇴 처리
  - 탈퇴 실패 조건:
    1. **프리랜서**: 참여 중인 프로젝트가 있는지 확인
       - 지원서가 `ACCEPT` 상태이면서, 해당 프로젝트의 `Status`가 `IN_PROGRESS` 또는 `COMPLETED`인 경우 탈퇴 불가
    2. **클라이언트**: 진행 중인 프로젝트가 있는지 확인
       - 프로젝트가 `IN_PROGRESS` 또는 `COMPLETED`인 경우 탈퇴 불가
  - 탈퇴 절차:
    - **Member 엔티티**: username, password, email, profileImgUrl를 null로, name을 `"탈퇴한 회원입니다."`, status를 `WITHDRAWN`으로 변경, deleteDate 기록
    - **Freelancer/Client 엔티티**: 주요 정보 null 처리
    - **프리랜서**: 지원서 중 `WAIT` 상태는 삭제, 제안서 중 `WAIT` 상태는 `DENIED`로 변경
    - **클라이언트**: 지원서 중 `WAIT` 상태는 `DENIED`로 변경, 제안서 중 `WAIT` 상태는 삭제, 오픈 중인 프로젝트는 `CLOSED` 처리
- 구현 편의상 **Freelancer, Client, Project 엔티티**에 OneToMany 관계 추가
- Controller에서는 간단한 테스트 호출만 진행
- Service 레이어에서 실제 값 변경 및 비식별화 여부 검증
- 지원서(Application) ENUM 타입 저장 문제 발견 및 수정
- BaseInitData에서 프로젝트/지원서/제안서 상태가 다양하지 않아, 현재는 **성공 케이스 중심 테스트**만 작성 가능

🛠 변경 파일 종류:
- 코드 (.java)
  - MemberService.java
  - MemberController.java
  - MemberServiceTest.java
  - MemberControllerTest.java
  - Freelancer.java
  - Client.java
  - Application.java, Proposal.java (ENUM 저장 수정)
  - BaseInitData.java
  - ...

### ✅ 체크리스트
- [x] 코드 빌드 성공
- [x] 테스트 통과
- [ ] 문서 업데이트
- [ ] 형식/스타일 가이드 준수
- [ ] 필요 시 마이그레이션/DB 변경 적용
- [ ] 제출 전 코드 포맷팅(ctrl + alt + L) 사용

### 🔗 관련 이슈
- 이슈 번호: #129 
- 참고 링크: 설계 문서, 참고 자료

### 💡 추가 설명 / 주의 사항
- 탈퇴 기능 구현 시 **성공 케이스 중심**으로 테스트 작성됨
- 프리랜서/클라이언트 비식별화 처리 및 연관 엔티티 상태 변경 검증 포함
- 지원서 및 제안서 상태 처리 로직에서 ENUM 타입 문제 발견 후 수정
- Controller에서는 API 호출만 간단히 테스트하고, Service에서 **값 변경 및 비식별화 검증** 수행
