### PR TITLE
✨ Feat[FE/BE] : 제안서 화면연동 추가 / 프리랜서 - 클라이언트 연결테이블 추가

### DIFF
--- a/backend/src/main/java/com/back/domain/application/application/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/back/domain/application/application/repository/ApplicationRepository.java
@@ -6,6 +6,7 @@ import com.back.domain.project.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,4 +21,16 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     Page<Application> findAllByFreelancer(Freelancer freelancer, Pageable pageable);
     Page<Application> findAllByProject(Project project, Pageable pageable);
+
+
+    @Query("""
+            SELECT a FROM Application a
+            JOIN FETCH a.project p
+            JOIN FETCH a.freelancer f
+            JOIN FETCH f.member fm
+            JOIN FETCH p.client c
+            JOIN FETCH c.member cm
+            WHERE a.id = :id
+    """)
+    Optional<Application> findByIdWithDetail(long id);
 }

--- a/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/back/domain/application/application/service/ApplicationService.java
@@ -7,13 +7,12 @@ import com.back.domain.application.application.repository.ApplicationRepository;
 import com.back.domain.freelancer.freelancer.entity.Freelancer;
 import com.back.domain.project.project.entity.Project;
 import com.back.global.exception.ServiceException;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +34,7 @@ public class ApplicationService {
     }
 
     public Application findById(long id) {
-        return applicationRepository.findById(id).orElseThrow(
+        return applicationRepository.findByIdWithDetail(id).orElseThrow(
                 () -> new ServiceException("401-1", "해당 지원서가 존재하지 않습니다.")
         );
     }

--- a/backend/src/main/java/com/back/domain/freelancer/freelancer/entity/Freelancer.java
+++ b/backend/src/main/java/com/back/domain/freelancer/freelancer/entity/Freelancer.java
@@ -5,6 +5,7 @@ import com.back.domain.common.skill.entity.Skill;
 import com.back.domain.freelancer.join.entity.FreelancerInterest;
 import com.back.domain.freelancer.join.entity.FreelancerSkill;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.project.participant.entity.ProjectParticipant;
 import com.back.domain.proposal.proposal.entity.Proposal;
 import com.back.standard.converter.JsonConverter;
 import jakarta.persistence.*;
@@ -43,7 +44,6 @@ public class Freelancer {
     private Integer careerTotalYears;
 
     @Column(name = "rating_avg")
-    //읽기전용?
     private double ratingAvg;
 
     @OneToMany(mappedBy = "freelancer", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -58,6 +58,9 @@ public class Freelancer {
 
     @OneToMany(mappedBy = "freelancer", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Proposal> proposals = new ArrayList<>();
+
+    @OneToMany(mappedBy = "freelancer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectParticipant> myProjects = new ArrayList<>();
 
     public Freelancer(Member member) {
         this.member = member;

--- a/backend/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -165,6 +165,15 @@ public class MemberController {
         return new ApiResponse<>("200-9", "내가 등록한 프로젝트 목록 조회 성공", projectSummaries);
     }
 
+    @GetMapping("/me/participated-projects")
+    public ApiResponse<List<ProjectSummaryDto>> getMyParticipatedProjects(@AuthenticationPrincipal CustomUserDetails user) {
+        Member member = memberService.findById(user.getId());
+
+        List<ProjectSummaryDto> data = projectService.findParticipatedProjectsById(member);
+
+        return new ApiResponse<>("200-9", "내가 참여한 프로젝트 목록 조회 성공", data);
+    }
+
     @GetMapping("/me/applications")
     public ApiResponse<List<ApplicationSummaryDto>> getMyApplications(@AuthenticationPrincipal CustomUserDetails user) {
         Member member = memberService.findById(user.getId());

--- a/backend/src/main/java/com/back/domain/project/participant/entity/ProjectParticipant.java
+++ b/backend/src/main/java/com/back/domain/project/participant/entity/ProjectParticipant.java
@@ -1,0 +1,50 @@
+package com.back.domain.project.participant.entity;
+
+
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.project.project.entity.Project;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Table(name = "project_participant")
+@Entity
+@NoArgsConstructor
+@Getter
+public class ProjectParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "freelancer_id")
+    private Freelancer freelancer;
+
+    // 착수일인지, 엔티티 생성일을 뜻하는지 잘 모르겠어서 @CreatedDate 추가하지 않음 일단 생성시 초기화
+    private LocalDateTime joinedAt;
+
+    private LocalDateTime endedAt;
+
+    public ProjectParticipant(Project project, Freelancer participant) {
+        this.project = project;
+        this.freelancer = participant;
+        this.joinedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/back/domain/project/project/entity/Project.java
+++ b/backend/src/main/java/com/back/domain/project/project/entity/Project.java
@@ -2,6 +2,8 @@ package com.back.domain.project.project.entity;
 
 import com.back.domain.application.application.entity.Application;
 import com.back.domain.client.client.entity.Client;
+import com.back.domain.freelancer.freelancer.entity.Freelancer;
+import com.back.domain.project.participant.entity.ProjectParticipant;
 import com.back.domain.project.project.constant.ProjectStatus;
 import com.back.domain.proposal.proposal.entity.Proposal;
 import com.back.global.jpa.entity.BaseEntity;
@@ -49,6 +51,9 @@ public class Project extends BaseEntity {
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Proposal> proposals = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectParticipant> projectParticipants = new ArrayList<>();
     
     public Project(
             Client client,
@@ -99,5 +104,11 @@ public class Project extends BaseEntity {
 
     public void updateStatus(ProjectStatus projectStatus) {
         this.status = projectStatus;
+    }
+
+    public void addParticipant(Freelancer participant) {
+        ProjectParticipant projectParticipant = new ProjectParticipant(this, participant);
+        this.projectParticipants.add(projectParticipant);
+        participant.getMyProjects().add(projectParticipant);
     }
 }

--- a/backend/src/main/java/com/back/domain/project/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/back/domain/project/project/repository/ProjectRepository.java
@@ -1,18 +1,17 @@
 package com.back.domain.project.project.repository;
 
 import com.back.domain.project.project.entity.Project;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project,Long>, ProjectRepositoryCustom {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
     Optional<Project> findFirstByOrderByIdDesc();
 
     @Query("SELECT p FROM Project p JOIN FETCH p.client c JOIN FETCH c.member WHERE p.id = :id")
@@ -22,4 +21,18 @@ public interface ProjectRepository extends JpaRepository<Project,Long>, ProjectR
 
     @Query("select p from Project p where p.client.id = :clientId")
     Page<Project> findByClientId(@Param("clientId") Long clientId, Pageable pageable);
+
+    @Query(
+            """
+                    SELECT DISTINCT p FROM Project p
+                    JOIN FETCH p.projectParticipants pp
+                    JOIN FETCH pp.freelancer f
+                    JOIN FETCH p.projectSkills ps
+                    JOIN FETCH ps.skill s
+                    JOIN FETCH p.projectInterests pi
+                    JOIN FETCH pi.interest i
+                    WHERE f.id = :freelancerId
+            """
+    )
+    List<Project> findParticipatedProjectsById(Long freelancerId);
 }

--- a/backend/src/main/java/com/back/domain/project/project/service/ProjectService.java
+++ b/backend/src/main/java/com/back/domain/project/project/service/ProjectService.java
@@ -205,4 +205,25 @@ public class ProjectService {
     public List<Project> findAllByMemberId(Long memberId) {
         return projectRepository.findAllByClientMemberIdOrderByIdDesc(memberId);
     }
+
+    @Transactional(readOnly = true)
+    public List<ProjectSummaryDto> findParticipatedProjectsById(Member member) {
+        if (!member.isFreelancer()) {
+            throw new ServiceException("403-1", "프리랜서만 접근할 수 있는 기능입니다.");
+        }
+
+        List<Project> myProjects = projectRepository.findParticipatedProjectsById(member.getId());
+
+        return myProjects.stream().map(project ->
+                new ProjectSummaryDto(
+                        project,
+                        project.getProjectSkills().stream()
+                                .map(ps -> new SkillDto(ps.getSkill()))
+                                .toList(),
+                        project.getProjectInterests().stream()
+                                .map(pi -> new InterestDto(pi.getInterest()))
+                                .toList()
+                )
+        ).toList();
+    }
 }

--- a/backend/src/main/java/com/back/domain/proposal/proposal/controller/ApiV1ProposalController.java
+++ b/backend/src/main/java/com/back/domain/proposal/proposal/controller/ApiV1ProposalController.java
@@ -26,14 +26,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/projects/{projectId}/proposals")
+@RequestMapping("/api/v1")
 @Tag(name="ApiV1ProposalController", description = "API 제안서(클라이언트 -> 프리랜서) 컨트롤러")
 public class ApiV1ProposalController {
 
     private final ProposalService proposalService;
     private final MemberService memberService;
 
-    @GetMapping
+    @GetMapping("/projects/{projectId}/proposals")
     @Operation(summary = "프로젝트에 해당하는 제안서 목록 조회")
     // NOTE : 권한 설정 및 DTO 데이터에 대한 변경 이후에 논의 필요함
     // 1. 프로젝트 작성자가 프로젝트에 해당하는 제안서를 모두 보려는 경우 -> 권한설정만 추가
@@ -49,7 +49,7 @@ public class ApiV1ProposalController {
         );
     }
 
-    @PostMapping
+    @PostMapping("/projects/{projectId}/proposals")
     @Operation(summary = "프로젝트에 제안서 등록")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<ProposalDto> create(
@@ -68,7 +68,7 @@ public class ApiV1ProposalController {
         );
     }
 
-    @GetMapping("/{proposalId}")
+    @GetMapping("/projects/{projectId}/proposals/{proposalId}")
     @Operation(summary = "프로젝트에 해당하는 특정 ID 제안서를 조회")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<ProposalDto> getProposal(
@@ -86,7 +86,7 @@ public class ApiV1ProposalController {
         );
     }
 
-    @PatchMapping("/{proposalId}")
+    @PatchMapping("/projects/{projectId}/proposals/{proposalId}")
     @Operation(summary = "프로젝트에 해당하는 특정 ID 제안서의 상태 변경")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<ProposalDto> updateState(
@@ -106,7 +106,7 @@ public class ApiV1ProposalController {
         );
     }
 
-    @DeleteMapping("/{proposalId}")
+    @DeleteMapping("/projects/{projectId}/proposals/{proposalId}")
     @Operation(summary = "프로젝트에 해당하는 특정 ID 제안서 삭제")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> delete(
@@ -121,6 +121,23 @@ public class ApiV1ProposalController {
         return new ApiResponse<>(
                 "204",
                 "제안서 삭제 성공"
+        );
+    }
+
+    // 자신과 관련된 모든 제안서 조회 (클라이언트 - 프리랜서 모두 가능)
+    @GetMapping("/proposals")
+    @Operation(summary = "자신과 관련된 모든 제안서 조회")
+    @SecurityRequirement(name = "bearerAuth")
+    public ApiResponse<List<ProposalDto>> getMyProposals(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Member member = memberService.findById(user.getId());
+        List<ProposalDto> proposals = proposalService.findAllByMember(member);
+
+        return new ApiResponse<>(
+                "200",
+                "자신과 관련된 제안서 목록 조회 성공",
+                proposals
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/proposal/proposal/repository/ProposalRepository.java
+++ b/backend/src/main/java/com/back/domain/proposal/proposal/repository/ProposalRepository.java
@@ -2,6 +2,7 @@ package com.back.domain.proposal.proposal.repository;
 
 import com.back.domain.proposal.proposal.entity.Proposal;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -33,4 +34,29 @@ public interface ProposalRepository extends JpaRepository<Proposal, Long> {
             """
     )
     Optional<Proposal> findByIdWithDetails(Long proposalId);
+
+
+    @Query("""
+                SELECT p FROM Proposal p
+                JOIN FETCH p.project pr
+                JOIN FETCH p.freelancer f
+                JOIN FETCH f.member fm
+                JOIN FETCH pr.client c
+                JOIN FETCH c.member cm
+                WHERE f.id = :freelancerId
+            """
+    )
+    List<Proposal> findByFreelancerIdWithDetails(Long freelancerId);
+
+    @Query("""
+                SELECT p FROM Proposal p
+                JOIN FETCH p.project pr
+                JOIN FETCH p.freelancer f
+                JOIN FETCH f.member fm
+                JOIN FETCH pr.client c
+                JOIN FETCH c.member cm
+                WHERE c.id = :id
+            """
+    )
+    List<Proposal> findByClientIdWithDetails(Long id);
 }

--- a/backend/src/main/java/com/back/domain/proposal/proposal/service/ProposalService.java
+++ b/backend/src/main/java/com/back/domain/proposal/proposal/service/ProposalService.java
@@ -11,6 +11,7 @@ import com.back.domain.proposal.proposal.entity.Proposal;
 import com.back.domain.proposal.proposal.repository.ProposalRepository;
 import com.back.global.exception.ServiceException;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -104,6 +105,10 @@ public class ProposalService {
 
         proposal.updateStatus(state);
 
+        if (state == ProposalStatus.ACCEPT) {
+            project.addParticipant(proposal.getFreelancer());
+        }
+
         return new ProposalDto(proposal);
     }
 
@@ -126,5 +131,18 @@ public class ProposalService {
     // 테스트를 위한 메소드
     public long count() {
         return proposalRepository.count();
+    }
+
+    public List<ProposalDto> findAllByMember(Member member) {
+        List<Proposal> proposals = new ArrayList<>();
+
+        if (member.isClient()) {
+            proposals = proposalRepository.findByClientIdWithDetails(member.getId());
+        }
+        if (member.isFreelancer()) {
+            proposals = proposalRepository.findByFreelancerIdWithDetails(member.getId());
+        }
+
+        return proposals.stream().map(ProposalDto::new).toList();
     }
 }

--- a/backend/src/main/java/com/back/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/com/back/global/initdata/BaseInitData.java
@@ -298,7 +298,11 @@ public class BaseInitData {
 
     @Transactional
     public void updateFreelancerInfo() {
-        Long freelancerId1 = memberService.findByUsername("freelancer1").get().getFreelancer().getId();
+        Freelancer freelancer1 = memberService.findByUsername("freelancer1").get().getFreelancer();
+        if (freelancer1.getJob() != null) {
+            return;
+        }
+        Long freelancerId1 = freelancer1.getId();
         Long freelancerId2 = memberService.findByUsername("freelancer2").get().getFreelancer().getId();
         Long freelancerId3 = memberService.findByUsername("freelancer3").get().getFreelancer().getId();
         Long freelancerId4 = memberService.findByUsername("freelancer4").get().getFreelancer().getId();
@@ -334,6 +338,10 @@ public class BaseInitData {
         List<Long> projectIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L);
         List<Integer> ratingsList = List.of(5, 4, 3, 2, 1, 1, 2, 2, 3, 4, 4, 5, 2, 3, 1, 4, 5);
         List<Long> evaluatorIds = List.of(2L, 3L);
+
+        if (memberService.findByUsername("freelancer6").get().getFreelancer().getJob() != null) {
+            return;
+        }
 
         for (int i = 6; i <= 50; i++) {
             Long freelancerId = memberService.findByUsername("freelancer" + i).get().getFreelancer().getId();

--- a/backend/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/global/security/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/members/me").authenticated() // 내 프로필 조회
                         .requestMatchers("/api/v1/members/me/profile").authenticated() // 내 프로필 수정
                         .requestMatchers("/api/v1/members/me/withdraw").authenticated() // 내 프로필 수정
+                        .requestMatchers(HttpMethod.GET,"/api/v1/proposals").authenticated() // 나의 제안서 조회
 
                         //평가 생성 및 수정은 인증된 사용자만 가능
                         .requestMatchers(HttpMethod.POST, "/api/v1/evaluations").authenticated()

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 /src/global/backend/apiV1/schema.d.ts
+/src/lib/backend/apiV1/schema.d.ts

--- a/frontend/src/pages/freelancers/[id]/propose/page.tsx
+++ b/frontend/src/pages/freelancers/[id]/propose/page.tsx
@@ -1,24 +1,145 @@
-import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { mockFreelancers, mockProjects } from '../../../../mocks/users';
+import { client } from '@/lib/backend/client';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import Button from '../../../../components/base/Button';
 import Select from '../../../../components/base/Select';
+import { useAuth } from '../../../../context/AuthContext';
+
+// 타입 정의
+type FreelancerData = {
+  id?: number;
+  name?: string;
+  careerLevel?: string;
+  ratingAvg?: number;
+  skills?: Array<{ id?: number; name?: string; }>;
+};
+
+type ProjectData = {
+  id?: number;
+  title?: string;
+  summary?: string; // 새 API에서는 summary 사용
+  budget?: number;  // 새 API에서는 price로 명명되지만 budget으로 매핑
+  status?: string;
+  ownerName?: string;
+  price?: number;   // 새 API 필드
+  duration?: string;
+  deadline?: string;
+  createDate?: string;
+  skills?: Array<{ id?: number; name?: string; }>;
+  interests?: Array<{ id?: number; name?: string; }>;
+};
 
 export default function FreelancerPropose() {
   const { id } = useParams();
+  const navigate = useNavigate();
+  const { user, token } = useAuth();
+  const [freelancer, setFreelancer] = useState<FreelancerData | null>(null);
+  const [myProjects, setMyProjects] = useState<ProjectData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     projectId: '',
     message: ''
   });
 
-  const freelancer = mockFreelancers.find(f => f.id === Number(id));
-  const myProjects = mockProjects.filter(p => p.clientId === 1); // 현재 클라이언트의 프로젝트
+  // 프리랜서 정보와 내 프로젝트 목록 가져오기
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // 로그인 체크
+        if (!user) {
+          alert('로그인이 필요합니다.');
+          navigate('/login');
+          return;
+        }
 
-  const handleSubmit = (e: React.FormEvent) => {
+        // 프리랜서 정보는 일단 목록에서 가져오는 것으로 처리 (개별 조회 API가 없다면)
+        // 실제로는 프리랜서 상세 API가 있어야 함
+        const freelancerData = {
+          id: Number(id),
+          name: `프리랜서 ${id}`,
+          careerLevel: 'MID',
+          ratingAvg: 4.5,
+          skills: []
+        };
+        setFreelancer(freelancerData);
+
+        // 내 프로젝트 목록 가져오기 - 새로운 API 사용
+        const { data: projectsResponse } = await client.GET("/api/v1/members/me/projects", {
+          headers: {
+            'Authorization': `Bearer ${token}`
+          }
+        });
+        if (projectsResponse?.data) {
+          // 새로운 API는 이미 현재 사용자의 프로젝트만 반환하므로 필터링 불필요
+          const userProjects = projectsResponse.data as ProjectData[];
+          setMyProjects(userProjects);
+          console.log('내 프로젝트 조회 성공:', userProjects.length, '개');
+        }
+      } catch (error) {
+        console.error('데이터 로딩 실패:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id, user, navigate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('프로젝트 제안:', formData);
-    alert('프로젝트 제안이 성공적으로 전송되었습니다!');
+
+    if (!formData.projectId || !formData.message.trim()) {
+      alert('모든 필수 항목을 입력해주세요.');
+      return;
+    }
+
+    if (formData.message.trim().length < 50) {
+      alert('메시지를 최소 50자 이상 작성해주세요.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const { data } = await client.POST("/api/v1/projects/{projectId}/proposals", {
+        params: {
+          path: {
+            projectId: Number(formData.projectId)
+          }
+        },
+        headers: {
+          'Authorization': `Bearer ${token}`
+        },
+        body: {
+          freelancerId: Number(id),
+          message: formData.message.trim()
+        }
+      });
+
+      if (data) {
+        alert('프로젝트 제안이 성공적으로 전송되었습니다!');
+        navigate(`/freelancers/${id}`);
+      } else {
+        throw new Error('제안 전송에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('제안 전송 실패:', error);
+      alert('제안 전송에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setSubmitting(false);
+    }
   };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   if (!freelancer) {
     return (
@@ -34,8 +155,8 @@ export default function FreelancerPropose() {
   }
 
   const projectOptions = myProjects.map(project => ({
-    value: project.id.toString(),
-    label: `${project.title} (${project.budget})`
+    value: project.id?.toString() || '',
+    label: `${project.title || '제목 없음'} (예산: ${(project.price || project.budget)?.toLocaleString() || '미정'}원)`
   }));
 
   return (
@@ -53,15 +174,20 @@ export default function FreelancerPropose() {
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
           <div className="flex items-center space-x-4">
             <div className="w-16 h-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white text-xl font-bold">
-              {freelancer.name.charAt(0)}
+              {freelancer.name?.charAt(0) || 'F'}
             </div>
             <div>
-              <h2 className="text-xl font-semibold text-gray-900">{freelancer.name}</h2>
-              <p className="text-gray-600">{freelancer.email}</p>
+              <h2 className="text-xl font-semibold text-gray-900">{freelancer.name || '프리랜서'}</h2>
               <div className="flex items-center mt-1">
                 <i className="ri-star-fill text-yellow-400 mr-1"></i>
-                <span className="text-sm font-medium">{freelancer.averageRating}</span>
-                <span className="text-sm text-gray-500 ml-2">경력: {freelancer.experience}</span>
+                <span className="text-sm font-medium">{freelancer.ratingAvg?.toFixed(1) || '0.0'}</span>
+                <span className="text-sm text-gray-500 ml-2">
+                  경력: {freelancer.careerLevel === 'NEWBIE' && '신입'}
+                  {freelancer.careerLevel === 'JUNIOR' && '주니어'}
+                  {freelancer.careerLevel === 'MID' && '미드'}
+                  {freelancer.careerLevel === 'SENIOR' && '시니어'}
+                  {freelancer.careerLevel === 'UNDEFINED' && '미입력'}
+                </span>
               </div>
             </div>
           </div>
@@ -74,65 +200,95 @@ export default function FreelancerPropose() {
             <p className="text-gray-600">프리랜서에게 프로젝트를 제안해보세요.</p>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <Select
-              label="제안할 프로젝트"
-              options={[
-                { value: '', label: '프로젝트를 선택하세요' },
-                ...projectOptions
-              ]}
-              value={formData.projectId}
-              onChange={(value) => setFormData(prev => ({ ...prev, projectId: value }))}
-              required
-            />
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                제안 메시지 <span className="text-red-500">*</span>
-              </label>
-              <textarea
-                value={formData.message}
-                onChange={(e) => setFormData(prev => ({ ...prev, message: e.target.value }))}
-                placeholder="프리랜서에게 전달할 메시지를 작성해주세요. 프로젝트에 대한 상세한 설명과 기대사항을 포함해주세요."
-                required
-                rows={8}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-              />
-              <p className="mt-1 text-sm text-gray-500">최소 50자 이상 작성해주세요.</p>
-            </div>
-
-            {/* 선택된 프로젝트 정보 */}
-            {formData.projectId && (
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <h3 className="font-semibold text-blue-900 mb-2">선택된 프로젝트</h3>
-                {(() => {
-                  const selectedProject = myProjects.find(p => p.id.toString() === formData.projectId);
-                  return selectedProject ? (
-                    <div className="text-sm text-blue-800">
-                      <p className="font-medium">{selectedProject.title}</p>
-                      <p className="mt-1">{selectedProject.description}</p>
-                      <div className="flex items-center space-x-4 mt-2">
-                        <span>예산: {selectedProject.budget}</span>
-                        <span>기간: {selectedProject.duration}</span>
-                      </div>
-                    </div>
-                  ) : null;
-                })()}
+          {myProjects.length === 0 ? (
+            <div className="text-center py-12">
+              <div className="p-6 bg-gray-50 rounded-xl inline-block">
+                <i className="ri-folder-2-line text-4xl text-gray-400 mb-4"></i>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">제안할 프로젝트가 없습니다</h3>
+                <p className="text-gray-500 mb-4">먼저 프로젝트를 등록한 후 제안해보세요.</p>
+                <div className="flex space-x-4 justify-center">
+                  <Link to="/projects/create">
+                    <Button className="rounded-xl">
+                      <i className="ri-add-line mr-2"></i>
+                      프로젝트 등록하기
+                    </Button>
+                  </Link>
+                  <Link to={`/freelancers/${freelancer.id}`}>
+                    <Button variant="outline" className="rounded-xl">
+                      프로필로 돌아가기
+                    </Button>
+                  </Link>
+                </div>
               </div>
-            )}
-
-            {/* 제출 버튼 */}
-            <div className="flex space-x-4 pt-6">
-              <Link to={`/freelancers/${freelancer.id}`} className="flex-1">
-                <Button variant="outline" className="w-full" size="lg">
-                  취소
-                </Button>
-              </Link>
-              <Button type="submit" className="flex-1" size="lg">
-                제안 전송
-              </Button>
             </div>
-          </form>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <Select
+                label="제안할 프로젝트"
+                options={[
+                  { value: '', label: '프로젝트를 선택하세요' },
+                  ...projectOptions
+                ]}
+                value={formData.projectId}
+                onChange={(value) => setFormData(prev => ({ ...prev, projectId: value }))}
+                required
+              />
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  제안 메시지 <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={formData.message}
+                  onChange={(e) => setFormData(prev => ({ ...prev, message: e.target.value }))}
+                  placeholder="프리랜서에게 전달할 메시지를 작성해주세요. 프로젝트에 대한 상세한 설명과 기대사항을 포함해주세요."
+                  required
+                  rows={8}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                />
+                <p className="mt-1 text-sm text-gray-500">최소 50자 이상 작성해주세요.</p>
+              </div>
+
+              {/* 선택된 프로젝트 정보 */}
+              {formData.projectId && (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                  <h3 className="font-semibold text-blue-900 mb-2">선택된 프로젝트</h3>
+                  {(() => {
+                    const selectedProject = myProjects.find(p => p.id?.toString() === formData.projectId);
+                    return selectedProject ? (
+                      <div className="text-sm text-blue-800">
+                        <p className="font-medium">{selectedProject.title || '제목 없음'}</p>
+                        <p className="mt-1">{selectedProject.summary || '설명 없음'}</p>
+                        <div className="flex items-center space-x-4 mt-2">
+                          <span>예산: {(selectedProject.price || selectedProject.budget)?.toLocaleString() || '미정'}원</span>
+                          <span>상태: {selectedProject.status || '미정'}</span>
+                        </div>
+                      </div>
+                    ) : null
+                  })()}
+                </div>
+              )}
+
+              {/* 제출 버튼 */}
+              <div className="flex space-x-4 pt-6">
+                <Link to={`/freelancers/${freelancer.id}`} className="flex-1">
+                  <Button variant="outline" className="w-full" size="lg" disabled={submitting}>
+                    취소
+                  </Button>
+                </Link>
+                <Button type="submit" className="flex-1" size="lg" disabled={submitting}>
+                  {submitting ? (
+                    <>
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                      전송 중...
+                    </>
+                  ) : (
+                    '제안 전송'
+                  )}
+                </Button>
+              </div>
+            </form>
+          )}
         </div>
 
         {/* 안내사항 */}


### PR DESCRIPTION

<img width="704" height="768" alt="image" src="https://github.com/user-attachments/assets/d1c4e41f-19c3-428b-97f8-c180d3dd1e32" />

프로젝트 - 프리랜서 연결테이블이 없는 관계로 프로젝트 findAll() -> 프론트에서 프리랜서 ID로 필터링한 프로젝트만 노출됨
(default 페이지인 10개의 프로젝트중 5개의 필터링된 프로젝트만 노출됨)

PR의 새로운 기능들로 인해 정상적으로 클라이언트들이 보유한 프로젝트 목록을 얻어낼 수 있는 API 생성

<img width="688" height="598" alt="image" src="https://github.com/user-attachments/assets/6b4c29f5-d337-4421-90d0-7fe9e309c30d" />


중요 비즈니스 기능 및 API, 엔티티 추가

기존에 구현 되어 있던 API
- 내가 등록한 프로젝트 목록 조회(클라이언트)
- 내가 지원한 지원서(application) 목록 조회(프리랜서)

추가된 엔티티 및 테이블
- Freelancer - Project 간 연결테이블 및 엔티티 추가 (ProjectParticipants)

추가된 기능 및 API
- 제안서나 지원서 수락시 연결테이블 생성 (테스트는 못했지만, AI에게 검수 받음)
- 내가 참여한 프로젝트 목록 조회(프리랜서)
- 자신과 관련된 모든 제안서(Proposal) 조회(클라이언트 / 프리랜서)

자잘한 수정
Application `findById` N + 1 문제 해결

논의가 필요한 부분

평가 (프리랜서 -> 프로젝트 -> 클라이언트) 문제 없음
평가 (클라이언트 -> 마이페이지 프로젝트 조회 -> 프리랜서가 여러명 일 수 있음)

어떤 페이지에서 이루어지던 새 API와 DTO 반드시 필요 (findBy(project Id) -> DTO에는 참가자 Id List가 필요)
마이프로필, 프리랜서 상세보기

